### PR TITLE
Mempool evict policy -- a few fixes 

### DIFF
--- a/consensus/core/src/tx.rs
+++ b/consensus/core/src/tx.rs
@@ -6,6 +6,7 @@ use kaspa_utils::mem_size::MemSizeEstimator;
 use kaspa_utils::{serde_bytes, serde_bytes_fixed_ref};
 pub use script_public_key::{scriptvec, ScriptPublicKey, ScriptPublicKeyVersion, ScriptPublicKeys, ScriptVec, SCRIPT_VECTOR_SIZE};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering::SeqCst;
 use std::{
@@ -442,6 +443,14 @@ impl<T: AsRef<Transaction>> MutableTransaction<T> {
     /// `estimate_mem_bytes` is sensitive to pointer wrappers such as Arc
     pub fn mempool_estimated_bytes(&self) -> usize {
         self.estimate_mem_bytes()
+    }
+
+    pub fn has_parent(&self, possible_parent: TransactionId) -> bool {
+        self.tx.as_ref().inputs.iter().any(|x| x.previous_outpoint.transaction_id == possible_parent)
+    }
+
+    pub fn has_parent_in_set(&self, possible_parents: &HashSet<TransactionId>) -> bool {
+        self.tx.as_ref().inputs.iter().any(|x| possible_parents.contains(&x.previous_outpoint.transaction_id))
     }
 }
 

--- a/mining/src/manager_tests.rs
+++ b/mining/src/manager_tests.rs
@@ -1125,7 +1125,7 @@ mod tests {
         let consensus = Arc::new(ConsensusMock::new());
         let counters = Arc::new(MiningCounters::default());
         let mut config = Config::build_default(TARGET_TIME_PER_BLOCK, false, MAX_BLOCK_MASS);
-        let tx_size = txs[0].tx.estimate_mem_bytes();
+        let tx_size = txs[0].mempool_estimated_bytes();
         let size_limit = TX_COUNT * tx_size;
         config.mempool_size_limit = size_limit;
         let mining_manager = MiningManager::with_config(config, None, counters);

--- a/mining/src/mempool/model/frontier.rs
+++ b/mining/src/mempool/model/frontier.rs
@@ -255,6 +255,7 @@ impl Frontier {
         estimator
     }
 
+    /// Returns an iterator to the transactions in the frontier in increasing feerate order
     pub fn ascending_iter(&self) -> impl DoubleEndedIterator<Item = &Arc<Transaction>> + ExactSizeIterator + FusedIterator {
         self.search_tree.ascending_iter().map(|key| &key.tx)
     }

--- a/mining/src/mempool/model/transactions_pool.rs
+++ b/mining/src/mempool/model/transactions_pool.rs
@@ -232,6 +232,20 @@ impl TransactionsPool {
             selection_overall_size += tx.mtx.mempool_estimated_bytes();
         }
 
+        // We could not find sufficient space for the pending transaction
+        if !(self.len() + 1 - txs_to_remove.len() <= self.config.maximum_transaction_count
+            && self.estimated_size + transaction_size - selection_overall_size <= self.config.mempool_size_limit)
+        {
+            let err = RuleError::RejectMempoolIsFull;
+            debug!(
+                "Mempool is filled with high-priority/ancestor txs. Transaction {} with feerate {} has been rejected: {}",
+                transaction.id(),
+                feerate_threshold,
+                err
+            );
+            return Err(err);
+        }
+
         Ok(txs_to_remove)
     }
 

--- a/mining/src/mempool/model/transactions_pool.rs
+++ b/mining/src/mempool/model/transactions_pool.rs
@@ -21,6 +21,7 @@ use kaspa_consensus_core::{
 use kaspa_core::{debug, time::unix_now, trace};
 use std::{
     collections::{hash_map::Keys, hash_set::Iter},
+    iter::once,
     sync::Arc,
 };
 
@@ -217,7 +218,7 @@ impl TransactionsPool {
             .filter(|mtx| mtx.priority == Priority::Low)
         {
             // TODO (optimization): inline the `has_parent_in_set` check within the redeemer traversal and exit early if possible
-            let redeemers = self.get_redeemer_ids_in_pool(&tx.id()).into_iter().collect::<TransactionIdSet>();
+            let redeemers = self.get_redeemer_ids_in_pool(&tx.id()).into_iter().chain(once(tx.id())).collect::<TransactionIdSet>();
             if transaction.has_parent_in_set(&redeemers) {
                 continue;
             }

--- a/mining/src/mempool/model/tx.rs
+++ b/mining/src/mempool/model/tx.rs
@@ -27,11 +27,6 @@ impl MempoolTransaction {
         assert!(contextual_mass > 0, "expected to be called for validated txs only");
         self.mtx.calculated_fee.unwrap() as f64 / contextual_mass as f64
     }
-
-    pub(crate) fn is_parent_of(&self, transaction: &MutableTransaction) -> bool {
-        let parent_id = self.id();
-        transaction.tx.inputs.iter().any(|x| x.previous_outpoint.transaction_id == parent_id)
-    }
 }
 
 impl RbfPolicy {

--- a/mining/src/mempool/validate_and_insert_transaction.rs
+++ b/mining/src/mempool/validate_and_insert_transaction.rs
@@ -81,7 +81,11 @@ impl Mempool {
             // self.transaction_pool.limit_transaction_count(&transaction) returns the
             // smallest prefix of `ready_transactions` (sorted by ascending fee-rate)
             // that makes enough room for `transaction`, but since each call to `self.remove_transaction`
-            // also removes all transactions dependant on `x` we might already have enough room.
+            // also removes all transactions dependant on `x` we might already have sufficient space, so
+            // we constantly check the break condition.
+            //
+            // Note that self.transaction_pool.len() < self.config.maximum_transaction_count means we have
+            // at least one available slot in terms of the count limit
             if self.transaction_pool.len() < self.config.maximum_transaction_count
                 && self.transaction_pool.get_estimated_size() + transaction_size <= self.config.mempool_size_limit
             {
@@ -92,7 +96,7 @@ impl Mempool {
         assert!(
             self.transaction_pool.len() < self.config.maximum_transaction_count
                 && self.transaction_pool.get_estimated_size() + transaction_size <= self.config.mempool_size_limit,
-            "Transactions in mempool: {}, max: {}, mempool size: {}, max: {}",
+            "Transactions in mempool: {}, max: {}, mempool bytes size: {}, max: {}",
             self.transaction_pool.len() + 1,
             self.config.maximum_transaction_count,
             self.transaction_pool.get_estimated_size() + transaction_size,


### PR DESCRIPTION
We should discuss:

1. Estimate size of populated entries -- I'm somewhat afraid of entry mutations and size inconsistency here. I know that at tx pool all txs are already fully populated and thus UTXO entries sizes should not change, but if feels fragile in terms of future dev. 
2. See [commit](https://github.com/someone235/rusty-kaspa/commit/5bbb43466fee30520133bb79c952213cbd64dcd1) message. Not sure about the external assert and we're not in beta mode anymore