### PR TITLE
External covenant context + Engine context refactor 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,21 @@ checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq",
+ "constant_time_eq 0.3.1",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if 1.0.0",
+ "constant_time_eq 0.4.2",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -900,6 +914,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,9 +958,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -2786,6 +2806,7 @@ name = "kaspa-hashes"
 version = "1.0.1"
 dependencies = [
  "blake2b_simd",
+ "blake3",
  "borsh",
  "cc",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,7 @@ base64 = "0.22.1"
 bincode = { version = "1.3.3", default-features = false }
 bitflags = "2.9.4"
 blake2b_simd = "1.0.2"
+blake3 = { version = "1.8.3", default-features = false }
 borsh = { version = "1.5.1", features = ["derive", "rc"] }
 bs58 = { version = "0.5.0", features = ["check"], default-features = false }
 bytes = "1.7.1"

--- a/consensus/benches/check_scripts.rs
+++ b/consensus/benches/check_scripts.rs
@@ -92,7 +92,7 @@ fn benchmark_check_scripts(c: &mut Criterion) {
                 let cache = Cache::new(inputs_count as u64);
                 b.iter(|| {
                     cache.clear();
-                    check_scripts_sequential(black_box(&cache), black_box(&tx.as_verifiable()), flags).unwrap();
+                    check_scripts_sequential(black_box(&cache), black_box(&tx.as_verifiable()), Default::default(), flags).unwrap();
                 })
             });
 
@@ -101,7 +101,7 @@ fn benchmark_check_scripts(c: &mut Criterion) {
                 let cache = Cache::new(inputs_count as u64);
                 b.iter(|| {
                     cache.clear();
-                    check_scripts_par_iter(black_box(&cache), black_box(&tx.as_verifiable()), flags).unwrap();
+                    check_scripts_par_iter(black_box(&cache), black_box(&tx.as_verifiable()), Default::default(), flags).unwrap();
                 })
             });
 
@@ -113,8 +113,14 @@ fn benchmark_check_scripts(c: &mut Criterion) {
                         let cache = Cache::new(inputs_count as u64);
                         b.iter(|| {
                             cache.clear();
-                            check_scripts_par_iter_pool(black_box(&cache), black_box(&tx.as_verifiable()), black_box(&pool), flags)
-                                .unwrap();
+                            check_scripts_par_iter_pool(
+                                black_box(&cache),
+                                black_box(&tx.as_verifiable()),
+                                Default::default(),
+                                black_box(&pool),
+                                flags,
+                            )
+                            .unwrap();
                         })
                     });
                 }
@@ -150,7 +156,8 @@ fn benchmark_check_scripts_with_payload(c: &mut Criterion) {
                 let cache = Cache::new(inputs_count as u64);
                 b.iter(|| {
                     cache.clear();
-                    check_scripts_par_iter(black_box(&cache), black_box(&tx.as_verifiable()), Default::default()).unwrap();
+                    check_scripts_par_iter(black_box(&cache), black_box(&tx.as_verifiable()), Default::default(), Default::default())
+                        .unwrap();
                 })
             });
         }

--- a/consensus/benches/check_scripts.rs
+++ b/consensus/benches/check_scripts.rs
@@ -3,12 +3,12 @@ use kaspa_addresses::{Address, Prefix, Version};
 use kaspa_consensus::processes::transaction_validator::tx_validation_in_utxo_context::{
     check_scripts_par_iter, check_scripts_par_iter_pool, check_scripts_sequential,
 };
-use kaspa_consensus_core::hashing::sighash::{calc_schnorr_signature_hash, SigHashReusedValuesUnsync};
+use kaspa_consensus_core::hashing::sighash::{calc_schnorr_signature_hash, SigHashReusedValuesSync, SigHashReusedValuesUnsync};
 use kaspa_consensus_core::hashing::sighash_type::SIG_HASH_ALL;
 use kaspa_consensus_core::subnets::SubnetworkId;
 use kaspa_consensus_core::tx::{MutableTransaction, Transaction, TransactionInput, TransactionOutpoint, UtxoEntry};
 use kaspa_txscript::caches::Cache;
-use kaspa_txscript::pay_to_address_script;
+use kaspa_txscript::{pay_to_address_script, EngineContext};
 use kaspa_utils::iter::parallelism_in_power_steps;
 use rand::{thread_rng, Rng};
 use secp256k1::Keypair;
@@ -92,7 +92,9 @@ fn benchmark_check_scripts(c: &mut Criterion) {
                 let cache = Cache::new(inputs_count as u64);
                 b.iter(|| {
                     cache.clear();
-                    check_scripts_sequential(black_box(&cache), black_box(&tx.as_verifiable()), Default::default(), flags).unwrap();
+                    let reused_values = SigHashReusedValuesUnsync::new();
+                    let ctx = EngineContext::new(&reused_values, black_box(&cache));
+                    check_scripts_sequential(black_box(&tx.as_verifiable()), ctx, flags).unwrap();
                 })
             });
 
@@ -101,7 +103,9 @@ fn benchmark_check_scripts(c: &mut Criterion) {
                 let cache = Cache::new(inputs_count as u64);
                 b.iter(|| {
                     cache.clear();
-                    check_scripts_par_iter(black_box(&cache), black_box(&tx.as_verifiable()), Default::default(), flags).unwrap();
+                    let reused_values = SigHashReusedValuesSync::new();
+                    let ctx = EngineContext::new(&reused_values, black_box(&cache));
+                    check_scripts_par_iter(black_box(&tx.as_verifiable()), ctx, flags).unwrap();
                 })
             });
 
@@ -113,14 +117,9 @@ fn benchmark_check_scripts(c: &mut Criterion) {
                         let cache = Cache::new(inputs_count as u64);
                         b.iter(|| {
                             cache.clear();
-                            check_scripts_par_iter_pool(
-                                black_box(&cache),
-                                black_box(&tx.as_verifiable()),
-                                Default::default(),
-                                black_box(&pool),
-                                flags,
-                            )
-                            .unwrap();
+                            let reused_values = SigHashReusedValuesSync::new();
+                            let ctx = EngineContext::new(&reused_values, black_box(&cache));
+                            check_scripts_par_iter_pool(black_box(&tx.as_verifiable()), ctx, flags, black_box(&pool)).unwrap();
                         })
                     });
                 }
@@ -156,8 +155,9 @@ fn benchmark_check_scripts_with_payload(c: &mut Criterion) {
                 let cache = Cache::new(inputs_count as u64);
                 b.iter(|| {
                     cache.clear();
-                    check_scripts_par_iter(black_box(&cache), black_box(&tx.as_verifiable()), Default::default(), Default::default())
-                        .unwrap();
+                    let reused_values = SigHashReusedValuesSync::new();
+                    let ctx = EngineContext::new(&reused_values, black_box(&cache));
+                    check_scripts_par_iter(black_box(&tx.as_verifiable()), ctx, Default::default()).unwrap();
                 })
             });
         }

--- a/consensus/benches/check_scripts.rs
+++ b/consensus/benches/check_scripts.rs
@@ -8,7 +8,7 @@ use kaspa_consensus_core::hashing::sighash_type::SIG_HASH_ALL;
 use kaspa_consensus_core::subnets::SubnetworkId;
 use kaspa_consensus_core::tx::{MutableTransaction, Transaction, TransactionInput, TransactionOutpoint, UtxoEntry};
 use kaspa_txscript::caches::Cache;
-use kaspa_txscript::{pay_to_address_script, EngineContext};
+use kaspa_txscript::{pay_to_address_script, EngineCtx};
 use kaspa_utils::iter::parallelism_in_power_steps;
 use rand::{thread_rng, Rng};
 use secp256k1::Keypair;
@@ -93,7 +93,7 @@ fn benchmark_check_scripts(c: &mut Criterion) {
                 b.iter(|| {
                     cache.clear();
                     let reused_values = SigHashReusedValuesUnsync::new();
-                    let ctx = EngineContext::new(&reused_values, black_box(&cache));
+                    let ctx = EngineCtx::new(black_box(&cache)).with_reused(&reused_values);
                     check_scripts_sequential(black_box(&tx.as_verifiable()), ctx, flags).unwrap();
                 })
             });
@@ -104,7 +104,7 @@ fn benchmark_check_scripts(c: &mut Criterion) {
                 b.iter(|| {
                     cache.clear();
                     let reused_values = SigHashReusedValuesSync::new();
-                    let ctx = EngineContext::new(&reused_values, black_box(&cache));
+                    let ctx = EngineCtx::new(black_box(&cache)).with_reused(&reused_values);
                     check_scripts_par_iter(black_box(&tx.as_verifiable()), ctx, flags).unwrap();
                 })
             });
@@ -118,7 +118,7 @@ fn benchmark_check_scripts(c: &mut Criterion) {
                         b.iter(|| {
                             cache.clear();
                             let reused_values = SigHashReusedValuesSync::new();
-                            let ctx = EngineContext::new(&reused_values, black_box(&cache));
+                            let ctx = EngineCtx::new(black_box(&cache)).with_reused(&reused_values);
                             check_scripts_par_iter_pool(black_box(&tx.as_verifiable()), ctx, flags, black_box(&pool)).unwrap();
                         })
                     });
@@ -156,7 +156,7 @@ fn benchmark_check_scripts_with_payload(c: &mut Criterion) {
                 b.iter(|| {
                     cache.clear();
                     let reused_values = SigHashReusedValuesSync::new();
-                    let ctx = EngineContext::new(&reused_values, black_box(&cache));
+                    let ctx = EngineCtx::new(black_box(&cache)).with_reused(&reused_values);
                     check_scripts_par_iter(black_box(&tx.as_verifiable()), ctx, Default::default()).unwrap();
                 })
             });

--- a/consensus/client/src/output.rs
+++ b/consensus/client/src/output.rs
@@ -4,8 +4,6 @@
 
 #![allow(non_snake_case)]
 
-use kaspa_consensus_core::tx::CovOutInfo;
-
 use crate::imports::*;
 
 #[wasm_bindgen(typescript_custom_section)]

--- a/consensus/client/src/output.rs
+++ b/consensus/client/src/output.rs
@@ -54,7 +54,7 @@ extern "C" {
 pub struct TransactionOutputInner {
     pub value: u64,
     pub script_public_key: ScriptPublicKey,
-    pub cov_out_info: Option<cctx::CovOutInfo>,
+    pub covenant: Option<cctx::CovenantBinding>,
 }
 
 /// Represents a Kaspad transaction output
@@ -67,8 +67,8 @@ pub struct TransactionOutput {
 }
 
 impl TransactionOutput {
-    pub fn new(value: u64, script_public_key: ScriptPublicKey, cov_out_info: Option<cctx::CovOutInfo>) -> TransactionOutput {
-        Self { inner: Arc::new(Mutex::new(TransactionOutputInner { value, script_public_key, cov_out_info })) }
+    pub fn new(value: u64, script_public_key: ScriptPublicKey, covenant: Option<cctx::CovenantBinding>) -> TransactionOutput {
+        Self { inner: Arc::new(Mutex::new(TransactionOutputInner { value, script_public_key, covenant })) }
     }
 
     pub fn new_with_inner(inner: TransactionOutputInner) -> Self {
@@ -88,10 +88,8 @@ impl TransactionOutput {
 impl TransactionOutput {
     #[wasm_bindgen(constructor)]
     /// TransactionOutput constructor
-    pub fn ctor(value: u64, script_public_key: &ScriptPublicKey, cov_out_info: Option<cctx::CovOutInfo>) -> TransactionOutput {
-        Self {
-            inner: Arc::new(Mutex::new(TransactionOutputInner { value, script_public_key: script_public_key.clone(), cov_out_info })),
-        }
+    pub fn ctor(value: u64, script_public_key: &ScriptPublicKey, covenant: Option<cctx::CovenantBinding>) -> TransactionOutput {
+        Self { inner: Arc::new(Mutex::new(TransactionOutputInner { value, script_public_key: script_public_key.clone(), covenant })) }
     }
 
     #[wasm_bindgen(getter, js_name = value)]
@@ -123,13 +121,13 @@ impl AsRef<TransactionOutput> for TransactionOutput {
 
 impl From<cctx::TransactionOutput> for TransactionOutput {
     fn from(output: cctx::TransactionOutput) -> Self {
-        TransactionOutput::new(output.value, output.script_public_key, output.cov_out_info)
+        TransactionOutput::new(output.value, output.script_public_key, output.covenant)
     }
 }
 
 impl From<&cctx::TransactionOutput> for TransactionOutput {
     fn from(output: &cctx::TransactionOutput) -> Self {
-        TransactionOutput::new(output.value, output.script_public_key.clone(), output.cov_out_info)
+        TransactionOutput::new(output.value, output.script_public_key.clone(), output.covenant)
     }
 }
 
@@ -150,8 +148,8 @@ impl TryCastFromJs for TransactionOutput {
             if let Some(object) = Object::try_from(value.as_ref()) {
                 let value = object.get_u64("value")?;
                 let script_public_key = ScriptPublicKey::try_owned_from(object.get_value("scriptPublicKey")?)?;
-                let cov_out_info = todo!();
-                Ok(TransactionOutput::new(value, script_public_key, cov_out_info).into())
+                let covenant = todo!();
+                Ok(TransactionOutput::new(value, script_public_key, covenant).into())
             } else {
                 Err("TransactionInput must be an object".into())
             }

--- a/consensus/client/src/serializable/numeric.rs
+++ b/consensus/client/src/serializable/numeric.rs
@@ -17,7 +17,7 @@ use ahash::AHashMap;
 use cctx::VerifiableTransaction;
 use kaspa_addresses::Address;
 use kaspa_consensus_core::subnets::SubnetworkId;
-use kaspa_consensus_core::tx::CovOutInfo;
+use kaspa_consensus_core::tx::CovenantBinding;
 use kaspa_hashes::Hash;
 use workflow_wasm::serde::{from_value, to_value};
 
@@ -190,32 +190,32 @@ impl TryFrom<&TransactionInput> for SerializableTransactionInput {
 pub struct SerializableTransactionOutput {
     pub value: u64,
     pub script_public_key: ScriptPublicKey,
-    pub cov_out_info: Option<CovOutInfo>,
+    pub covenant: Option<CovenantBinding>,
 }
 
 impl From<cctx::TransactionOutput> for SerializableTransactionOutput {
     fn from(output: cctx::TransactionOutput) -> Self {
-        Self { value: output.value, script_public_key: output.script_public_key, cov_out_info: output.cov_out_info }
+        Self { value: output.value, script_public_key: output.script_public_key, covenant: output.covenant }
     }
 }
 
 impl From<&cctx::TransactionOutput> for SerializableTransactionOutput {
     fn from(output: &cctx::TransactionOutput) -> Self {
-        Self { value: output.value, script_public_key: output.script_public_key.clone(), cov_out_info: output.cov_out_info }
+        Self { value: output.value, script_public_key: output.script_public_key.clone(), covenant: output.covenant }
     }
 }
 
 impl TryFrom<SerializableTransactionOutput> for cctx::TransactionOutput {
     type Error = Error;
     fn try_from(output: SerializableTransactionOutput) -> Result<Self> {
-        Ok(Self { value: output.value, script_public_key: output.script_public_key, cov_out_info: output.cov_out_info })
+        Ok(Self { value: output.value, script_public_key: output.script_public_key, covenant: output.covenant })
     }
 }
 
 impl TryFrom<&SerializableTransactionOutput> for TransactionOutput {
     type Error = Error;
     fn try_from(output: &SerializableTransactionOutput) -> Result<Self> {
-        Ok(TransactionOutput::new(output.value, output.script_public_key.clone(), output.cov_out_info))
+        Ok(TransactionOutput::new(output.value, output.script_public_key.clone(), output.covenant))
     }
 }
 
@@ -223,7 +223,7 @@ impl TryFrom<&TransactionOutput> for SerializableTransactionOutput {
     type Error = Error;
     fn try_from(output: &TransactionOutput) -> Result<Self> {
         let inner = output.inner();
-        Ok(Self { value: inner.value, script_public_key: inner.script_public_key.clone(), cov_out_info: inner.cov_out_info.clone() })
+        Ok(Self { value: inner.value, script_public_key: inner.script_public_key.clone(), covenant: inner.covenant.clone() })
     }
 }
 

--- a/consensus/client/src/serializable/numeric.rs
+++ b/consensus/client/src/serializable/numeric.rs
@@ -223,7 +223,7 @@ impl TryFrom<&TransactionOutput> for SerializableTransactionOutput {
     type Error = Error;
     fn try_from(output: &TransactionOutput) -> Result<Self> {
         let inner = output.inner();
-        Ok(Self { value: inner.value, script_public_key: inner.script_public_key.clone(), covenant: inner.covenant.clone() })
+        Ok(Self { value: inner.value, script_public_key: inner.script_public_key.clone(), covenant: inner.covenant })
     }
 }
 

--- a/consensus/client/src/serializable/string.rs
+++ b/consensus/client/src/serializable/string.rs
@@ -182,36 +182,32 @@ impl TryFrom<&TransactionInput> for SerializableTransactionInput {
 pub struct SerializableTransactionOutput {
     pub value: String,
     pub script_public_key: ScriptPublicKey,
-    pub cov_out_info: Option<cctx::CovOutInfo>,
+    pub covenant: Option<cctx::CovenantBinding>,
 }
 
 impl From<cctx::TransactionOutput> for SerializableTransactionOutput {
     fn from(output: cctx::TransactionOutput) -> Self {
-        Self { value: output.value.to_string(), script_public_key: output.script_public_key, cov_out_info: output.cov_out_info }
+        Self { value: output.value.to_string(), script_public_key: output.script_public_key, covenant: output.covenant }
     }
 }
 
 impl From<&cctx::TransactionOutput> for SerializableTransactionOutput {
     fn from(output: &cctx::TransactionOutput) -> Self {
-        Self {
-            value: output.value.to_string(),
-            script_public_key: output.script_public_key.clone(),
-            cov_out_info: output.cov_out_info,
-        }
+        Self { value: output.value.to_string(), script_public_key: output.script_public_key.clone(), covenant: output.covenant }
     }
 }
 
 impl TryFrom<SerializableTransactionOutput> for cctx::TransactionOutput {
     type Error = Error;
     fn try_from(output: SerializableTransactionOutput) -> Result<Self> {
-        Ok(Self { value: output.value.parse()?, script_public_key: output.script_public_key, cov_out_info: output.cov_out_info })
+        Ok(Self { value: output.value.parse()?, script_public_key: output.script_public_key, covenant: output.covenant })
     }
 }
 
 impl TryFrom<&SerializableTransactionOutput> for TransactionOutput {
     type Error = Error;
     fn try_from(output: &SerializableTransactionOutput) -> Result<Self> {
-        Ok(TransactionOutput::new(output.value.parse()?, output.script_public_key.clone(), output.cov_out_info))
+        Ok(TransactionOutput::new(output.value.parse()?, output.script_public_key.clone(), output.covenant))
     }
 }
 
@@ -219,11 +215,7 @@ impl TryFrom<&TransactionOutput> for SerializableTransactionOutput {
     type Error = Error;
     fn try_from(output: &TransactionOutput) -> Result<Self> {
         let inner = output.inner();
-        Ok(Self {
-            value: inner.value.to_string(),
-            script_public_key: inner.script_public_key.clone(),
-            cov_out_info: inner.cov_out_info,
-        })
+        Ok(Self { value: inner.value.to_string(), script_public_key: inner.script_public_key.clone(), covenant: inner.covenant })
     }
 }
 

--- a/consensus/core/benches/serde_benchmark.rs
+++ b/consensus/core/benches/serde_benchmark.rs
@@ -43,8 +43,8 @@ fn serialize_benchmark(c: &mut Criterion) {
             },
         ],
         vec![
-            TransactionOutput { value: 300, script_public_key: script_public_key.clone(), cov_out_info: None },
-            TransactionOutput { value: 300, script_public_key, cov_out_info: None },
+            TransactionOutput { value: 300, script_public_key: script_public_key.clone(), covenant: None },
+            TransactionOutput { value: 300, script_public_key, covenant: None },
         ],
         0,
         SUBNETWORK_ID_COINBASE,
@@ -105,8 +105,8 @@ fn deserialize_benchmark(c: &mut Criterion) {
             },
         ],
         vec![
-            TransactionOutput { value: 300, script_public_key: script_public_key.clone(), cov_out_info: None },
-            TransactionOutput { value: 300, script_public_key, cov_out_info: None },
+            TransactionOutput { value: 300, script_public_key: script_public_key.clone(), covenant: None },
+            TransactionOutput { value: 300, script_public_key, covenant: None },
         ],
         0,
         SUBNETWORK_ID_COINBASE,

--- a/consensus/core/src/errors/tx.rs
+++ b/consensus/core/src/errors/tx.rs
@@ -101,8 +101,8 @@ pub enum TxRuleError {
     #[error("fee rate per contextual mass gram is not greater than the fee rate of the replaced transaction")]
     FeerateTooLow,
 
-    #[error("transaction output #{0} has cov_out_info field but transaction version is below 1")]
-    CovOutInfoInPreCovTxVersion(usize),
+    #[error("transaction output #{0} has covenant field but transaction version is below 1")]
+    CovenantBindingInPreCovTxVersion(usize),
 
     #[error("output #{0} has covenant id doesn't correspond to the referenced input covenant id")]
     WrongCovenantId(usize),

--- a/consensus/core/src/errors/tx.rs
+++ b/consensus/core/src/errors/tx.rs
@@ -1,7 +1,7 @@
 use crate::constants::MAX_SOMPI;
 use crate::subnets::SubnetworkId;
 use crate::tx::TransactionOutpoint;
-use kaspa_txscript_errors::TxScriptError;
+use kaspa_txscript_errors::{CovenantsError, TxScriptError};
 use thiserror::Error;
 
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
@@ -104,8 +104,8 @@ pub enum TxRuleError {
     #[error("transaction output #{0} has covenant field but transaction version is below 1")]
     CovenantBindingInPreCovTxVersion(usize),
 
-    #[error("output #{0} has covenant id doesn't correspond to the referenced input covenant id")]
-    WrongCovenantId(usize),
+    #[error("covenants error: {0}")]
+    CovenantsError(#[from] CovenantsError),
 }
 
 pub type TxResult<T> = std::result::Result<T, TxRuleError>;

--- a/consensus/core/src/hashing/sighash.rs
+++ b/consensus/core/src/hashing/sighash.rs
@@ -230,9 +230,9 @@ pub fn hash_output(hasher: &mut impl Hasher, output: &TransactionOutput, version
     hash_script_public_key(hasher, &output.script_public_key);
 
     if version >= 1 {
-        hasher.write_bool(output.cov_out_info.is_some());
-        if let Some(cov_out_info) = &output.cov_out_info {
-            hasher.write_u16(cov_out_info.authorizing_input).update(cov_out_info.covenant_id);
+        hasher.write_bool(output.covenant.is_some());
+        if let Some(covenant) = &output.covenant {
+            hasher.write_u16(covenant.authorizing_input).update(covenant.covenant_id);
         }
     }
 }
@@ -332,16 +332,8 @@ mod tests {
                 },
             ],
             vec![
-                TransactionOutput {
-                    value: 300,
-                    script_public_key: ScriptPublicKey::new(0, script_pub_key_2.clone()),
-                    cov_out_info: None,
-                },
-                TransactionOutput {
-                    value: 300,
-                    script_public_key: ScriptPublicKey::new(0, script_pub_key_1.clone()),
-                    cov_out_info: None,
-                },
+                TransactionOutput { value: 300, script_public_key: ScriptPublicKey::new(0, script_pub_key_2.clone()), covenant: None },
+                TransactionOutput { value: 300, script_public_key: ScriptPublicKey::new(0, script_pub_key_1.clone()), covenant: None },
             ],
             1615462089000,
             SUBNETWORK_ID_NATIVE,

--- a/consensus/core/src/hashing/tx.rs
+++ b/consensus/core/src/hashing/tx.rs
@@ -115,7 +115,7 @@ fn write_output<T: HasherBase>(hasher: &mut T, output: &TransactionOutput, versi
         hasher.write_bool(output.cov_out_info.is_some());
         if let Some(cov_out_info) = &output.cov_out_info {
             hasher.write_u16(cov_out_info.authorizing_input);
-            hasher.update(&cov_out_info.covenant_id);
+            hasher.update(cov_out_info.covenant_id);
         }
     }
 }

--- a/consensus/core/src/hashing/tx.rs
+++ b/consensus/core/src/hashing/tx.rs
@@ -112,10 +112,10 @@ fn write_output<T: HasherBase>(hasher: &mut T, output: &TransactionOutput, versi
         .write_var_bytes(output.script_public_key.script());
 
     if version >= 1 {
-        hasher.write_bool(output.cov_out_info.is_some());
-        if let Some(cov_out_info) = &output.cov_out_info {
-            hasher.write_u16(cov_out_info.authorizing_input);
-            hasher.update(cov_out_info.covenant_id);
+        hasher.write_bool(output.covenant.is_some());
+        if let Some(covenant) = &output.covenant {
+            hasher.write_u16(covenant.authorizing_input);
+            hasher.update(covenant.covenant_id);
         }
     }
 }

--- a/consensus/core/src/mass/mod.rs
+++ b/consensus/core/src/mass/mod.rs
@@ -93,7 +93,7 @@ impl UtxoPlurality for UtxoEntry {
 
 impl UtxoPlurality for TransactionOutput {
     fn plurality(&self) -> u64 {
-        utxo_plurality(&self.script_public_key, self.cov_out_info.is_some())
+        utxo_plurality(&self.script_public_key, self.covenant.is_some())
     }
 }
 
@@ -703,7 +703,7 @@ mod tests {
                 .map(|out_amount| TransactionOutput {
                     value: out_amount,
                     script_public_key: ScriptPublicKey::new(0, script_pub_key.clone()),
-                    cov_out_info: None,
+                    covenant: None,
                 })
                 .collect(),
             1615462089000,

--- a/consensus/core/src/merkle.rs
+++ b/consensus/core/src/merkle.rs
@@ -39,7 +39,7 @@ mod tests {
                             0xba, 0x30, 0xcd, 0x5a, 0x4b, 0x87,
                         ],
                     ),
-                    cov_out_info: None,
+                    covenant: None,
                 }],
                 0,
                 SUBNETWORK_ID_COINBASE,
@@ -120,7 +120,7 @@ mod tests {
                                 0xac, // OP_CHECKSIG
                             ],
                         ),
-                        cov_out_info: None,
+                        covenant: None,
                     },
                     TransactionOutput {
                         value: 0x108e20f00,
@@ -135,7 +135,7 @@ mod tests {
                                 0xac, // OP_CHECKSIG
                             ],
                         ),
-                        cov_out_info: None,
+                        covenant: None,
                     },
                 ],
                 0,
@@ -182,7 +182,7 @@ mod tests {
                                 0xac, // OP_CHECKSIG
                             ],
                         ),
-                        cov_out_info: None,
+                        covenant: None,
                     },
                     TransactionOutput {
                         value: 0x11d260c0,
@@ -197,7 +197,7 @@ mod tests {
                                 0xac, // OP_CHECKSIG
                             ],
                         ),
-                        cov_out_info: None,
+                        covenant: None,
                     },
                 ],
                 0,
@@ -244,7 +244,7 @@ mod tests {
                             0xac, // OP_CHECKSIG
                         ],
                     ),
-                    cov_out_info: None,
+                    covenant: None,
                 }],
                 0,
                 SUBNETWORK_ID_NATIVE,

--- a/consensus/core/src/muhash.rs
+++ b/consensus/core/src/muhash.rs
@@ -22,7 +22,13 @@ impl MuHashExtensions for MuHash {
         }
         for (i, output) in tx.outputs().iter().enumerate() {
             let outpoint = TransactionOutpoint::new(tx_id, i as u32);
-            let entry = UtxoEntry::new(output.value, output.script_public_key.clone(), block_daa_score, tx.is_coinbase(), output.cov_out_info.map(|info| info.covenant_id));
+            let entry = UtxoEntry::new(
+                output.value,
+                output.script_public_key.clone(),
+                block_daa_score,
+                tx.is_coinbase(),
+                output.cov_out_info.map(|info| info.covenant_id),
+            );
             self.add_utxo(&outpoint, &entry);
         }
     }

--- a/consensus/core/src/muhash.rs
+++ b/consensus/core/src/muhash.rs
@@ -27,7 +27,7 @@ impl MuHashExtensions for MuHash {
                 output.script_public_key.clone(),
                 block_daa_score,
                 tx.is_coinbase(),
-                output.cov_out_info.map(|info| info.covenant_id),
+                output.covenant.map(|info| info.covenant_id),
             );
             self.add_utxo(&outpoint, &entry);
         }

--- a/consensus/core/src/sign.rs
+++ b/consensus/core/src/sign.rs
@@ -223,16 +223,8 @@ mod tests {
                 },
             ],
             vec![
-                TransactionOutput {
-                    value: 300,
-                    script_public_key: ScriptPublicKey::new(0, script_pub_key.clone()),
-                    cov_out_info: None,
-                },
-                TransactionOutput {
-                    value: 300,
-                    script_public_key: ScriptPublicKey::new(0, script_pub_key.clone()),
-                    cov_out_info: None,
-                },
+                TransactionOutput { value: 300, script_public_key: ScriptPublicKey::new(0, script_pub_key.clone()), covenant: None },
+                TransactionOutput { value: 300, script_public_key: ScriptPublicKey::new(0, script_pub_key.clone()), covenant: None },
             ],
             1615462089000,
             SubnetworkId::from_bytes([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),

--- a/consensus/core/src/tx.rs
+++ b/consensus/core/src/tx.rs
@@ -132,19 +132,20 @@ impl std::fmt::Debug for TransactionInput {
 pub struct TransactionOutput {
     pub value: u64,
     pub script_public_key: ScriptPublicKey,
-    pub cov_out_info: Option<CovOutInfo>,
+    pub covenant: Option<CovenantBinding>,
 }
 
 impl TransactionOutput {
     pub fn new(value: u64, script_public_key: ScriptPublicKey) -> Self {
-        Self { value, script_public_key, cov_out_info: None }
+        Self { value, script_public_key, covenant: None }
     }
 }
 
+/// Binds a transaction output to the covenant and input authorizing its creation.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Copy, CastFromJs)]
 #[serde(rename_all = "camelCase")]
 #[wasm_bindgen(inspectable)]
-pub struct CovOutInfo {
+pub struct CovenantBinding {
     pub authorizing_input: u16,
     pub covenant_id: Hash,
 }
@@ -637,8 +638,8 @@ mod tests {
                 },
             ],
             vec![
-                TransactionOutput { value: 6, script_public_key: script_public_key.clone(), cov_out_info: None },
-                TransactionOutput { value: 7, script_public_key, cov_out_info: None },
+                TransactionOutput { value: 6, script_public_key: script_public_key.clone(), covenant: None },
+                TransactionOutput { value: 7, script_public_key, covenant: None },
             ],
             8,
             SUBNETWORK_ID_NATIVE,
@@ -712,12 +713,12 @@ mod tests {
     {
       "value": 6,
       "scriptPublicKey": "000076a921032f7e430aa4c9d159437e84b975dc76d9003bf0922cf3aa4528464bab780dba5e",
-      "covOutInfo": null
+      "covenant": null
     },
     {
       "value": 7,
       "scriptPublicKey": "000076a921032f7e430aa4c9d159437e84b975dc76d9003bf0922cf3aa4528464bab780dba5e",
-      "covOutInfo": null
+      "covenant": null
     }
   ],
   "lockTime": 8,

--- a/consensus/core/src/utxo/utxo_diff.rs
+++ b/consensus/core/src/utxo/utxo_diff.rs
@@ -236,7 +236,7 @@ impl UtxoDiff {
                 output.script_public_key.clone(),
                 block_daa_score,
                 is_coinbase,
-                output.cov_out_info.map(|x| x.covenant_id),
+                output.covenant.map(|x| x.covenant_id),
             );
             self.add_entry(outpoint, entry)?;
         }

--- a/consensus/src/model/services/mod.rs
+++ b/consensus/src/model/services/mod.rs
@@ -1,3 +1,4 @@
 pub mod reachability;
 pub mod relations;
+pub mod seq_commit_accessor;
 pub mod statuses;

--- a/consensus/src/model/services/reachability.rs
+++ b/consensus/src/model/services/reachability.rs
@@ -11,24 +11,33 @@ use kaspa_hashes::Hash;
 pub trait ReachabilityService {
     /// Checks if `this` block is a chain ancestor of `queried` block (i.e., `this ∈ chain(queried) ∪ {queried}`).
     /// Note that we use the graph theory convention here which defines that a block is also an ancestor of itself.
-    fn is_chain_ancestor_of(&self, this: Hash, queried: Hash) -> bool;
+    fn is_chain_ancestor_of(&self, this: Hash, queried: Hash) -> bool {
+        self.try_is_chain_ancestor_of(this, queried).unwrap()
+    }
+
+    /// Result version of [`Self::is_chain_ancestor_of`] (avoids unwrapping internally)
+    fn try_is_chain_ancestor_of(&self, this: Hash, queried: Hash) -> Result<bool>;
 
     /// Result version of [`Self::is_dag_ancestor_of`] (avoids unwrapping internally)
-    fn is_dag_ancestor_of_result(&self, this: Hash, queried: Hash) -> Result<bool>;
+    fn try_is_dag_ancestor_of(&self, this: Hash, queried: Hash) -> Result<bool>;
 
     /// Returns true if `this` is a DAG ancestor of `queried` (i.e., `queried ∈ future(this) ∪ {this}`).
     /// Note: this method will return true if `this == queried`.
     /// The complexity of this method is `O(log(|future_covering_set(this)|))`
-    fn is_dag_ancestor_of(&self, this: Hash, queried: Hash) -> bool;
+    fn is_dag_ancestor_of(&self, this: Hash, queried: Hash) -> bool {
+        self.try_is_dag_ancestor_of(this, queried).unwrap()
+    }
 
     /// Checks if `this` is DAG ancestor of any of the blocks in `queried`. See [`Self::is_dag_ancestor_of`] as well.
     fn is_dag_ancestor_of_any(&self, this: Hash, queried: &mut impl Iterator<Item = Hash>) -> bool;
 
     /// Checks if any of the blocks in `list` is DAG ancestor of `queried`. See [`Self::is_dag_ancestor_of`] as well.
-    fn is_any_dag_ancestor(&self, list: &mut impl Iterator<Item = Hash>, queried: Hash) -> bool;
+    fn is_any_dag_ancestor(&self, list: &mut impl Iterator<Item = Hash>, queried: Hash) -> bool {
+        self.try_is_any_dag_ancestor(list, queried).unwrap()
+    }
 
     /// Result version of [`Self::is_any_dag_ancestor`] (avoids unwrapping internally)
-    fn is_any_dag_ancestor_result(&self, list: &mut impl Iterator<Item = Hash>, queried: Hash) -> Result<bool>;
+    fn try_is_any_dag_ancestor(&self, list: &mut impl Iterator<Item = Hash>, queried: Hash) -> Result<bool>;
 
     /// Finds the tree child of `ancestor` which is also a chain ancestor of `descendant`.
     /// (A "tree child of X" is a block which X is its chain parent)
@@ -42,27 +51,19 @@ pub trait ReachabilityService {
 }
 
 impl<T: ReachabilityStoreReader + ?Sized> ReachabilityService for T {
-    fn is_chain_ancestor_of(&self, this: Hash, queried: Hash) -> bool {
-        inquirer::is_chain_ancestor_of(self, this, queried).unwrap()
+    fn try_is_chain_ancestor_of(&self, this: Hash, queried: Hash) -> Result<bool> {
+        inquirer::is_chain_ancestor_of(self, this, queried)
     }
 
-    fn is_dag_ancestor_of_result(&self, this: Hash, queried: Hash) -> Result<bool> {
+    fn try_is_dag_ancestor_of(&self, this: Hash, queried: Hash) -> Result<bool> {
         inquirer::is_dag_ancestor_of(self, this, queried)
-    }
-
-    fn is_dag_ancestor_of(&self, this: Hash, queried: Hash) -> bool {
-        inquirer::is_dag_ancestor_of(self, this, queried).unwrap()
     }
 
     fn is_dag_ancestor_of_any(&self, this: Hash, queried: &mut impl Iterator<Item = Hash>) -> bool {
         queried.any(|hash| inquirer::is_dag_ancestor_of(self, this, hash).unwrap())
     }
 
-    fn is_any_dag_ancestor(&self, list: &mut impl Iterator<Item = Hash>, queried: Hash) -> bool {
-        list.any(|hash| inquirer::is_dag_ancestor_of(self, hash, queried).unwrap())
-    }
-
-    fn is_any_dag_ancestor_result(&self, list: &mut impl Iterator<Item = Hash>, queried: Hash) -> Result<bool> {
+    fn try_is_any_dag_ancestor(&self, list: &mut impl Iterator<Item = Hash>, queried: Hash) -> Result<bool> {
         for hash in list {
             if inquirer::is_dag_ancestor_of(self, hash, queried)? {
                 return Ok(true);
@@ -97,33 +98,23 @@ impl<T: ReachabilityStoreReader + ?Sized> MTReachabilityService<T> {
 }
 
 impl<T: ReachabilityStoreReader + ?Sized> ReachabilityService for MTReachabilityService<T> {
-    fn is_chain_ancestor_of(&self, this: Hash, queried: Hash) -> bool {
+    fn try_is_chain_ancestor_of(&self, this: Hash, queried: Hash) -> Result<bool> {
         let read_guard = self.store.read();
-        inquirer::is_chain_ancestor_of(read_guard.deref(), this, queried).unwrap()
+        inquirer::is_chain_ancestor_of(read_guard.deref(), this, queried)
     }
 
-    fn is_dag_ancestor_of_result(&self, this: Hash, queried: Hash) -> Result<bool> {
+    fn try_is_dag_ancestor_of(&self, this: Hash, queried: Hash) -> Result<bool> {
         let read_guard = self.store.read();
         inquirer::is_dag_ancestor_of(read_guard.deref(), this, queried)
-    }
-
-    fn is_dag_ancestor_of(&self, this: Hash, queried: Hash) -> bool {
-        let read_guard = self.store.read();
-        inquirer::is_dag_ancestor_of(read_guard.deref(), this, queried).unwrap()
-    }
-
-    fn is_any_dag_ancestor(&self, list: &mut impl Iterator<Item = Hash>, queried: Hash) -> bool {
-        let read_guard = self.store.read();
-        list.any(|hash| inquirer::is_dag_ancestor_of(read_guard.deref(), hash, queried).unwrap())
-    }
-
-    fn is_any_dag_ancestor_result(&self, list: &mut impl Iterator<Item = Hash>, queried: Hash) -> Result<bool> {
-        self.store.read().is_any_dag_ancestor_result(list, queried)
     }
 
     fn is_dag_ancestor_of_any(&self, this: Hash, queried: &mut impl Iterator<Item = Hash>) -> bool {
         let read_guard = self.store.read();
         queried.any(|hash| inquirer::is_dag_ancestor_of(read_guard.deref(), this, hash).unwrap())
+    }
+
+    fn try_is_any_dag_ancestor(&self, list: &mut impl Iterator<Item = Hash>, queried: Hash) -> Result<bool> {
+        self.store.read().try_is_any_dag_ancestor(list, queried)
     }
 
     fn get_next_chain_ancestor(&self, descendant: Hash, ancestor: Hash) -> Hash {

--- a/consensus/src/model/services/seq_commit_accessor.rs
+++ b/consensus/src/model/services/seq_commit_accessor.rs
@@ -1,0 +1,42 @@
+use crate::model::services::reachability::{MTReachabilityService, ReachabilityService};
+use crate::model::stores::headers::{DbHeadersStore, HeaderStoreReader};
+use crate::model::stores::reachability::DbReachabilityStore;
+use kaspa_database::prelude::StoreResultExt;
+use kaspa_hashes::Hash;
+
+#[derive(Copy, Clone)]
+pub struct SeqCommitAccessor<'a> {
+    pub threshold: u64,
+
+    pub sp: Hash,
+    pub sp_blue_score: Option<u64>,
+    pub reachability_service: &'a MTReachabilityService<DbReachabilityStore>,
+    pub headers_store: &'a DbHeadersStore,
+}
+
+impl<'a> SeqCommitAccessor<'a> {
+    pub fn new(
+        sp: Hash,
+        reachability_service: &'a MTReachabilityService<DbReachabilityStore>,
+        headers_store: &'a DbHeadersStore,
+        threshold: u64,
+    ) -> Self {
+        Self { threshold, sp, sp_blue_score: None, reachability_service, headers_store }
+    }
+}
+
+impl<'a> kaspa_txscript::SeqCommitAccessor for SeqCommitAccessor<'a> {
+    fn is_chain_ancestor_from_pov(&self, block_hash: Hash) -> Option<bool> {
+        self.reachability_service.try_is_chain_ancestor_of(block_hash, self.sp).optional().unwrap()
+    }
+
+    fn seq_commitment_within_depth(&self, block_hash: Hash) -> Option<Hash> {
+        let header = self.headers_store.get_header(block_hash).optional().unwrap()?;
+        let sp_blue_score = self.sp_blue_score.unwrap_or_else(|| self.headers_store.get_blue_score(self.sp).unwrap());
+        if sp_blue_score < header.blue_score + self.threshold {
+            Some(header.accepted_id_merkle_root)
+        } else {
+            None
+        }
+    }
+}

--- a/consensus/src/pipeline/body_processor/body_validation_in_isolation.rs
+++ b/consensus/src/pipeline/body_processor/body_validation_in_isolation.rs
@@ -197,7 +197,7 @@ mod tests {
                                 0xba, 0x30, 0xcd, 0x5a, 0x4b, 0x87
                             ),
                         ),
-                        cov_out_info: None,
+                        covenant: None,
                     }],
                     0,
                     SUBNETWORK_ID_COINBASE,
@@ -278,7 +278,7 @@ mod tests {
                                     0xac  // OP_CHECKSIG
                                 ),
                             ),
-                            cov_out_info: None,
+                            covenant: None,
                         },
                         TransactionOutput {
                             value: 0x108e20f00,
@@ -293,7 +293,7 @@ mod tests {
                                     0xac  // OP_CHECKSIG
                                 ),
                             ),
-                            cov_out_info: None,
+                            covenant: None,
                         },
                     ],
                     0,
@@ -340,7 +340,7 @@ mod tests {
                                     0xac  // OP_CHECKSIG
                                 ),
                             ),
-                            cov_out_info: None,
+                            covenant: None,
                         },
                         TransactionOutput {
                             value: 0x11d260c0,
@@ -355,7 +355,7 @@ mod tests {
                                     0xac  // OP_CHECKSIG
                                 ),
                             ),
-                            cov_out_info: None,
+                            covenant: None,
                         },
                     ],
                     0,
@@ -402,7 +402,7 @@ mod tests {
                                 0xac  // OP_CHECKSIG
                             ),
                         ),
-                        cov_out_info: None,
+                        covenant: None,
                     }],
                     0,
                     SUBNETWORK_ID_NATIVE,

--- a/consensus/src/pipeline/pruning_processor/processor.rs
+++ b/consensus/src/pipeline/pruning_processor/processor.rs
@@ -409,7 +409,7 @@ impl PruningProcessor {
                 .read()
                 .iter()
                 .copied()
-                .filter(|&h| !reachability_read.is_dag_ancestor_of_result(new_pruning_point, h).unwrap())
+                .filter(|&h| !reachability_read.try_is_dag_ancestor_of(new_pruning_point, h).unwrap())
                 .collect_vec();
             tips_write.prune_tips_with_writer(BatchDbWriter::new(&mut batch), &pruned_tips).unwrap();
             if !pruned_tips.is_empty() {
@@ -446,7 +446,7 @@ impl PruningProcessor {
         let (mut counter, mut traversed) = (0, 0);
         info!("Header and Block pruning: starting traversal from: {} (genesis: {})", queue.iter().reusable_format(", "), genesis);
         while let Some(current) = queue.pop_front() {
-            if reachability_read.is_dag_ancestor_of_result(retention_period_root, current).unwrap() {
+            if reachability_read.try_is_dag_ancestor_of(retention_period_root, current).unwrap() {
                 continue;
             }
             traversed += 1;

--- a/consensus/src/pipeline/virtual_processor/utxo_inquirer.rs
+++ b/consensus/src/pipeline/virtual_processor/utxo_inquirer.rs
@@ -145,7 +145,7 @@ impl VirtualStateProcessor {
             output.script_public_key.clone(),
             accepting_block_daa_score,
             other_tx.is_coinbase(),
-            output.cov_out_info.map(|x| x.covenant_id),
+            output.covenant.map(|x| x.covenant_id),
         );
         Ok(utxo_entry)
     }
@@ -185,7 +185,7 @@ impl VirtualStateProcessor {
                             output.script_public_key.clone(),
                             accepting_daa_score,
                             tx.is_coinbase(),
-                            output.cov_out_info.map(|x| x.covenant_id),
+                            output.covenant.map(|x| x.covenant_id),
                         ))
                     } else {
                         None
@@ -251,7 +251,7 @@ impl VirtualStateProcessor {
                             output.script_public_key.clone(),
                             accepting_daa_score,
                             tx.is_coinbase(),
-                            output.cov_out_info.map(|x| x.covenant_id),
+                            output.covenant.map(|x| x.covenant_id),
                         ))
                     } else {
                         None

--- a/consensus/src/processes/pruning_proof/build.rs
+++ b/consensus/src/processes/pruning_proof/build.rs
@@ -59,7 +59,7 @@ impl<T: RelationsStoreReader, U: ReachabilityService> RelationsStoreReader for R
                     .copied()
                     // TODO(relaxed): consider removing this filtering altogether - in the context this is currently called
                     // blocks should not be inserted if they do not fulfill this condition
-                    .filter(|h| self.reachability_service.is_dag_ancestor_of_result(self.root, *h).optional().unwrap().unwrap_or(false))
+                    .filter(|h| self.reachability_service.try_is_dag_ancestor_of(self.root, *h).optional().unwrap().unwrap_or(false))
                     .collect_vec(),
             )
         })
@@ -269,7 +269,7 @@ impl PruningProofManager {
                     .parents_at_level(&header, level)
                     .iter()
                     .copied()
-                    .filter(|&p| self.reachability_service.is_dag_ancestor_of_result(root, p).optional().unwrap().unwrap_or(false))
+                    .filter(|&p| self.reachability_service.try_is_dag_ancestor_of(root, p).optional().unwrap().unwrap_or(false))
                     .collect::<Vec<_>>()
                     .push_if_empty(ORIGIN),
             );

--- a/consensus/src/processes/transaction_validator/tx_validation_in_header_context.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_header_context.rs
@@ -48,7 +48,7 @@ impl TransactionValidator {
         lock_time_arg: LockTimeArg,
         block_daa_score: u64,
     ) -> TxResult<()> {
-        self.check_tx_is_finalized(tx, lock_time_arg);
+        self.check_tx_is_finalized(tx, lock_time_arg)?;
         self.check_transaction_version(tx, block_daa_score)
     }
 

--- a/consensus/src/processes/transaction_validator/tx_validation_in_isolation.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_isolation.rs
@@ -1,4 +1,4 @@
-use crate::constants::{MAX_SOMPI, TX_VERSION, TX_VERSION_POST_COV_HF};
+use crate::constants::{MAX_SOMPI, TX_VERSION_POST_COV_HF};
 use kaspa_consensus_core::tx::Transaction;
 use std::collections::HashSet;
 

--- a/consensus/src/processes/transaction_validator/tx_validation_in_isolation.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_isolation.rs
@@ -164,8 +164,8 @@ fn check_transaction_subnetwork(tx: &Transaction) -> TxResult<()> {
 
 fn check_tx_version_specific_fields(tx: &Transaction) -> TxResult<()> {
     for (i, output) in tx.outputs.iter().enumerate() {
-        if tx.version < 1 && output.cov_out_info.is_some() {
-            return Err(TxRuleError::CovOutInfoInPreCovTxVersion(i));
+        if tx.version < 1 && output.covenant.is_some() {
+            return Err(TxRuleError::CovenantBindingInPreCovTxVersion(i));
         }
     }
 
@@ -214,7 +214,7 @@ mod tests {
                         0x30, 0xcd, 0x5a, 0x4b, 0x87
                     ),
                 ),
-                cov_out_info: None,
+                covenant: None,
             }],
             0,
             SUBNETWORK_ID_COINBASE,
@@ -264,7 +264,7 @@ mod tests {
                             0xac  // OP_CHECKSIG
                         ),
                     ),
-                    cov_out_info: None,
+                    covenant: None,
                 },
                 TransactionOutput {
                     value: 0x108e20f00,
@@ -279,7 +279,7 @@ mod tests {
                             0xac  // OP_CHECKSIG
                         ),
                     ),
-                    cov_out_info: None,
+                    covenant: None,
                 },
             ],
             0,

--- a/consensus/src/processes/transaction_validator/tx_validation_in_isolation.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_isolation.rs
@@ -175,15 +175,15 @@ fn check_tx_version_specific_fields(tx: &Transaction) -> TxResult<()> {
 #[cfg(test)]
 mod tests {
     use kaspa_consensus_core::{
+        constants::{TX_VERSION, TX_VERSION_POST_COV_HF},
         subnets::{SubnetworkId, SUBNETWORK_ID_COINBASE, SUBNETWORK_ID_NATIVE},
         tx::{scriptvec, ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput},
     };
     use kaspa_core::assert_match;
 
     use crate::{
-        constants::TX_VERSION,
         params::MAINNET_PARAMS,
-        processes::transaction_validator::{errors::TxRuleError, TransactionValidator},
+        processes::transaction_validator::{errors::TxRuleError, tx_validation_in_header_context::LockTimeArg, TransactionValidator},
     };
 
     #[test]
@@ -326,8 +326,14 @@ mod tests {
         tx.payload = vec![0];
         assert_match!(tv.validate_tx_in_isolation(&tx), Ok(()));
 
+        let mut tx = valid_tx.clone();
+        tx.version = TX_VERSION_POST_COV_HF + 1;
+        assert_match!(tv.validate_tx_in_isolation(&tx), Err(TxRuleError::UnknownTxVersion(_)));
+
+        // Test prev version upper bound in header context
+        // TODO (covpp): turn back into pure in-isolation test
         let mut tx = valid_tx;
         tx.version = TX_VERSION + 1;
-        assert_match!(tv.validate_tx_in_isolation(&tx), Err(TxRuleError::UnknownTxVersion(_)));
+        assert_match!(tv.validate_tx_in_header_context(&tx, LockTimeArg::Finalized, 0), Err(TxRuleError::UnknownTxVersion(_)));
     }
 }

--- a/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
@@ -3,11 +3,13 @@ use kaspa_consensus_core::{
     hashing::sighash::{SigHashReusedValuesSync, SigHashReusedValuesUnsync},
     tx::{TransactionInput, VerifiableTransaction},
 };
-use kaspa_txscript::{caches::Cache, get_sig_op_count_upper_bound, EngineFlags, SigCacheKey, TxScriptEngine};
+use kaspa_txscript::{
+    caches::Cache, get_sig_op_count_upper_bound, CovenantInputContext, CovenantsContext, EngineFlags, SigCacheKey, TxScriptEngine,
+};
 use kaspa_txscript_errors::TxScriptError;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rayon::ThreadPool;
-use std::marker::Sync;
+use std::{collections::hash_map::Entry, marker::Sync};
 
 use super::{
     errors::{TxResult, TxRuleError},
@@ -51,11 +53,11 @@ impl TransactionValidator {
         // The following call is not a consensus check (it could not be one in the first place since it uses a floating number)
         // but rather a mempool Replace by Fee validation rule. It is placed here purposely for avoiding unneeded script checks.
         Self::check_feerate_threshold(fee, mass_and_feerate_threshold)?;
-        self.check_covenant_info(tx, block_daa_score)?;
+        let covenants_ctx = self.check_covenant_info(tx, block_daa_score)?;
 
         match flags {
             TxValidationFlags::Full | TxValidationFlags::SkipMassCheck => {
-                self.check_scripts(tx, block_daa_score)?;
+                self.check_scripts_with_covenants(tx, covenants_ctx, block_daa_score)?;
             }
             TxValidationFlags::SkipScriptChecks => {}
         }
@@ -168,17 +170,39 @@ impl TransactionValidator {
     }
 
     pub fn check_scripts(&self, tx: &(impl VerifiableTransaction + Sync), block_daa_score: u64) -> TxResult<()> {
-        check_scripts(&self.sig_cache, tx, EngineFlags { covenants_enabled: self.covenants_activation.is_active(block_daa_score) })
+        check_scripts(
+            &self.sig_cache,
+            tx,
+            Default::default(),
+            EngineFlags { covenants_enabled: self.covenants_activation.is_active(block_daa_score) },
+        )
     }
 
-    fn check_covenant_info(&self, tx: &impl VerifiableTransaction, block_daa_score: u64) -> TxResult<()> {
+    pub fn check_scripts_with_covenants(
+        &self,
+        tx: &(impl VerifiableTransaction + Sync),
+        covenants_ctx: CovenantsContext,
+        block_daa_score: u64,
+    ) -> TxResult<()> {
+        check_scripts(
+            &self.sig_cache,
+            tx,
+            covenants_ctx,
+            EngineFlags { covenants_enabled: self.covenants_activation.is_active(block_daa_score) },
+        )
+    }
+
+    fn check_covenant_info(&self, tx: &impl VerifiableTransaction, block_daa_score: u64) -> TxResult<CovenantsContext> {
         if !self.covenants_activation.is_active(block_daa_score) {
-            return Ok(());
+            return Ok(Default::default());
         }
+
+        let mut ctx = CovenantsContext::default();
 
         for (i, output) in tx.outputs().iter().enumerate() {
             if let Some(cov_out_info) = &output.cov_out_info {
-                let Some(utxo_entry) = tx.utxo(cov_out_info.authorizing_input as usize) else {
+                let auth_input = cov_out_info.authorizing_input as usize;
+                let Some(utxo_entry) = tx.utxo(auth_input) else {
                     // TODO: Change to another error
                     return Err(TxRuleError::MissingTxOutpoints);
                 };
@@ -187,39 +211,51 @@ impl TransactionValidator {
                         return Err(TxRuleError::WrongCovenantId(i));
                     }
                 } else {
-                    let authorizing_input = &tx.inputs()[cov_out_info.authorizing_input as usize]; // It's guaranteed to exist from the earlier check on the UTXO entry.
+                    let authorizing_input = &tx.inputs()[auth_input]; // Guaranteed to exist from the earlier check on the UTXO entry.
                     if kaspa_consensus_core::hashing::covenant_id::covenant_id(authorizing_input.previous_outpoint)
                         != cov_out_info.covenant_id
                     {
                         return Err(TxRuleError::WrongCovenantId(i));
                     }
                 }
+
+                match ctx.per_input_ctx.entry(auth_input) {
+                    Entry::Occupied(mut e) => {
+                        e.get_mut().output_indices.push(i);
+                    }
+                    Entry::Vacant(e) => {
+                        e.insert(CovenantInputContext { covenant_id: cov_out_info.covenant_id, output_indices: vec![i] });
+                    }
+                };
             }
         }
-        Ok(())
+
+        Ok(ctx)
     }
 }
 
 pub fn check_scripts(
     sig_cache: &Cache<SigCacheKey, bool>,
     tx: &(impl VerifiableTransaction + Sync),
+    covenants_ctx: CovenantsContext,
     flags: EngineFlags,
 ) -> TxResult<()> {
     if tx.inputs().len() > CHECK_SCRIPTS_PARALLELISM_THRESHOLD {
-        check_scripts_par_iter(sig_cache, tx, flags)
+        check_scripts_par_iter(sig_cache, tx, covenants_ctx, flags)
     } else {
-        check_scripts_sequential(sig_cache, tx, flags)
+        check_scripts_sequential(sig_cache, tx, covenants_ctx, flags)
     }
 }
 
 pub fn check_scripts_sequential(
     sig_cache: &Cache<SigCacheKey, bool>,
     tx: &impl VerifiableTransaction,
+    covenants_ctx: CovenantsContext,
     flags: EngineFlags,
 ) -> TxResult<()> {
     let reused_values = SigHashReusedValuesUnsync::new();
     for (i, (input, entry)) in tx.populated_inputs().enumerate() {
-        TxScriptEngine::from_transaction_input(tx, input, i, entry, &reused_values, sig_cache, flags)
+        TxScriptEngine::from_transaction_input_with_covenants(tx, input, i, entry, &reused_values, &covenants_ctx, sig_cache, flags)
             .execute()
             .map_err(|err| map_script_err(err, input))?;
     }
@@ -229,12 +265,13 @@ pub fn check_scripts_sequential(
 pub fn check_scripts_par_iter(
     sig_cache: &Cache<SigCacheKey, bool>,
     tx: &(impl VerifiableTransaction + Sync),
+    covenants_ctx: CovenantsContext,
     flags: EngineFlags,
 ) -> TxResult<()> {
     let reused_values = SigHashReusedValuesSync::new();
     (0..tx.inputs().len()).into_par_iter().try_for_each(|idx| {
         let (input, utxo) = tx.populated_input(idx);
-        TxScriptEngine::from_transaction_input(tx, input, idx, utxo, &reused_values, sig_cache, flags)
+        TxScriptEngine::from_transaction_input_with_covenants(tx, input, idx, utxo, &reused_values, &covenants_ctx, sig_cache, flags)
             .execute()
             .map_err(|err| map_script_err(err, input))
     })
@@ -243,10 +280,11 @@ pub fn check_scripts_par_iter(
 pub fn check_scripts_par_iter_pool(
     sig_cache: &Cache<SigCacheKey, bool>,
     tx: &(impl VerifiableTransaction + Sync),
+    covenants_ctx: CovenantsContext,
     pool: &ThreadPool,
     flags: EngineFlags,
 ) -> TxResult<()> {
-    pool.install(|| check_scripts_par_iter(sig_cache, tx, flags))
+    pool.install(|| check_scripts_par_iter(sig_cache, tx, covenants_ctx, flags))
 }
 
 fn map_script_err(script_err: TxScriptError, input: &TransactionInput) -> TxRuleError {

--- a/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
@@ -4,7 +4,9 @@ use kaspa_consensus_core::{
     tx::{TransactionInput, VerifiableTransaction},
 };
 use kaspa_txscript::{
-    caches::Cache, get_sig_op_count_upper_bound, CovenantLocalContext, CovenantsContext, EngineFlags, SigCacheKey, TxScriptEngine,
+    caches::Cache,
+    covenants::{CovenantGlobalContext, CovenantLocalContext, CovenantsContext},
+    get_sig_op_count_upper_bound, EngineFlags, SigCacheKey, TxScriptEngine,
 };
 use kaspa_txscript_errors::TxScriptError;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -199,6 +201,19 @@ impl TransactionValidator {
 
         let mut ctx = CovenantsContext::default();
 
+        for (i, (_, entry)) in tx.populated_inputs().enumerate() {
+            if let Some(covenant_id) = entry.covenant_id {
+                match ctx.covenant_ctxs.entry(covenant_id) {
+                    Entry::Occupied(mut e) => {
+                        e.get_mut().input_indices.push(i);
+                    }
+                    Entry::Vacant(e) => {
+                        e.insert(CovenantGlobalContext { input_indices: vec![i], output_indices: Default::default() });
+                    }
+                }
+            }
+        }
+
         for (i, output) in tx.outputs().iter().enumerate() {
             if let Some(cov_out_info) = &output.cov_out_info {
                 let auth_input = cov_out_info.authorizing_input as usize;
@@ -221,12 +236,21 @@ impl TransactionValidator {
 
                 match ctx.local_ctxs.entry(auth_input) {
                     Entry::Occupied(mut e) => {
-                        e.get_mut().authorized_outputs.push(i);
+                        e.get_mut().auth_outputs.push(i);
                     }
                     Entry::Vacant(e) => {
-                        e.insert(CovenantLocalContext { covenant_id: cov_out_info.covenant_id, authorized_outputs: vec![i] });
+                        e.insert(CovenantLocalContext { covenant_id: cov_out_info.covenant_id, auth_outputs: vec![i] });
                     }
-                };
+                }
+
+                match ctx.covenant_ctxs.entry(cov_out_info.covenant_id) {
+                    Entry::Occupied(mut e) => {
+                        e.get_mut().output_indices.push(i);
+                    }
+                    Entry::Vacant(e) => {
+                        e.insert(CovenantGlobalContext { input_indices: Default::default(), output_indices: vec![i] });
+                    }
+                }
             }
         }
 

--- a/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
@@ -6,7 +6,7 @@ use kaspa_consensus_core::{
 use kaspa_txscript::{
     caches::Cache,
     covenants::{CovenantGlobalContext, CovenantLocalContext, CovenantsContext},
-    get_sig_op_count_upper_bound, EngineFlags, SigCacheKey, TxScriptEngine,
+    get_sig_op_count_upper_bound, EngineContext, EngineFlags, SigCacheKey, TxScriptEngine,
 };
 use kaspa_txscript_errors::TxScriptError;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -278,10 +278,9 @@ pub fn check_scripts_sequential(
     flags: EngineFlags,
 ) -> TxResult<()> {
     let reused_values = SigHashReusedValuesUnsync::new();
+    let ctx = EngineContext::with_covenants_ctx(&reused_values, sig_cache, &covenants_ctx);
     for (i, (input, entry)) in tx.populated_inputs().enumerate() {
-        TxScriptEngine::from_transaction_input_with_covenants(tx, input, i, entry, &reused_values, &covenants_ctx, sig_cache, flags)
-            .execute()
-            .map_err(|err| map_script_err(err, input))?;
+        TxScriptEngine::from_transaction_input(tx, input, i, entry, ctx, flags).execute().map_err(|err| map_script_err(err, input))?;
     }
     Ok(())
 }
@@ -293,11 +292,10 @@ pub fn check_scripts_par_iter(
     flags: EngineFlags,
 ) -> TxResult<()> {
     let reused_values = SigHashReusedValuesSync::new();
+    let ctx = EngineContext::with_covenants_ctx(&reused_values, sig_cache, &covenants_ctx);
     (0..tx.inputs().len()).into_par_iter().try_for_each(|idx| {
         let (input, utxo) = tx.populated_input(idx);
-        TxScriptEngine::from_transaction_input_with_covenants(tx, input, idx, utxo, &reused_values, &covenants_ctx, sig_cache, flags)
-            .execute()
-            .map_err(|err| map_script_err(err, input))
+        TxScriptEngine::from_transaction_input(tx, input, idx, utxo, ctx, flags).execute().map_err(|err| map_script_err(err, input))
     })
 }
 

--- a/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
@@ -4,7 +4,7 @@ use kaspa_consensus_core::{
     tx::{TransactionInput, VerifiableTransaction},
 };
 use kaspa_txscript::{
-    caches::Cache, get_sig_op_count_upper_bound, CovenantInputContext, CovenantsContext, EngineFlags, SigCacheKey, TxScriptEngine,
+    caches::Cache, get_sig_op_count_upper_bound, CovenantLocalContext, CovenantsContext, EngineFlags, SigCacheKey, TxScriptEngine,
 };
 use kaspa_txscript_errors::TxScriptError;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -219,12 +219,12 @@ impl TransactionValidator {
                     }
                 }
 
-                match ctx.per_input_ctx.entry(auth_input) {
+                match ctx.local_ctxs.entry(auth_input) {
                     Entry::Occupied(mut e) => {
-                        e.get_mut().output_indices.push(i);
+                        e.get_mut().authorized_outputs.push(i);
                     }
                     Entry::Vacant(e) => {
-                        e.insert(CovenantInputContext { covenant_id: cov_out_info.covenant_id, output_indices: vec![i] });
+                        e.insert(CovenantLocalContext { covenant_id: cov_out_info.covenant_id, authorized_outputs: vec![i] });
                     }
                 };
             }

--- a/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
@@ -4,9 +4,8 @@ use kaspa_consensus_core::{
     tx::{TransactionInput, VerifiableTransaction},
 };
 use kaspa_txscript::{
-    caches::Cache,
     covenants::{CovenantGlobalContext, CovenantLocalContext, CovenantsContext},
-    get_sig_op_count_upper_bound, EngineContext, EngineFlags, SigCacheKey, TxScriptEngine,
+    get_sig_op_count_upper_bound, EngineContext, EngineFlags, MissingReusedValues, TxScriptEngine,
 };
 use kaspa_txscript_errors::TxScriptError;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -59,7 +58,7 @@ impl TransactionValidator {
 
         match flags {
             TxValidationFlags::Full | TxValidationFlags::SkipMassCheck => {
-                self.check_scripts_with_covenants(tx, covenants_ctx, block_daa_score)?;
+                self.check_scripts(tx, covenants_ctx, block_daa_score)?;
             }
             TxValidationFlags::SkipScriptChecks => {}
         }
@@ -171,27 +170,15 @@ impl TransactionValidator {
         Ok(())
     }
 
-    pub fn check_scripts(&self, tx: &(impl VerifiableTransaction + Sync), block_daa_score: u64) -> TxResult<()> {
-        check_scripts(
-            &self.sig_cache,
-            tx,
-            Default::default(),
-            EngineFlags { covenants_enabled: self.covenants_activation.is_active(block_daa_score) },
-        )
-    }
-
-    pub fn check_scripts_with_covenants(
+    pub fn check_scripts(
         &self,
         tx: &(impl VerifiableTransaction + Sync),
         covenants_ctx: CovenantsContext,
         block_daa_score: u64,
     ) -> TxResult<()> {
-        check_scripts(
-            &self.sig_cache,
-            tx,
-            covenants_ctx,
-            EngineFlags { covenants_enabled: self.covenants_activation.is_active(block_daa_score) },
-        )
+        let ctx = EngineContext::with_missing(&self.sig_cache).with_covenants_ctx(&covenants_ctx);
+        let flags = EngineFlags { covenants_enabled: self.covenants_activation.is_active(block_daa_score) };
+        check_scripts(tx, ctx, flags)
     }
 
     fn check_covenant_info(&self, tx: &impl VerifiableTransaction, block_daa_score: u64) -> TxResult<CovenantsContext> {
@@ -259,26 +246,24 @@ impl TransactionValidator {
 }
 
 pub fn check_scripts(
-    sig_cache: &Cache<SigCacheKey, bool>,
     tx: &(impl VerifiableTransaction + Sync),
-    covenants_ctx: CovenantsContext,
+    ctx: EngineContext<'_, MissingReusedValues>,
     flags: EngineFlags,
 ) -> TxResult<()> {
     if tx.inputs().len() > CHECK_SCRIPTS_PARALLELISM_THRESHOLD {
-        check_scripts_par_iter(sig_cache, tx, covenants_ctx, flags)
+        let reused_values = SigHashReusedValuesSync::new();
+        check_scripts_par_iter(tx, ctx.with_reused(&reused_values), flags)
     } else {
-        check_scripts_sequential(sig_cache, tx, covenants_ctx, flags)
+        let reused_values = SigHashReusedValuesUnsync::new();
+        check_scripts_sequential(tx, ctx.with_reused(&reused_values), flags)
     }
 }
 
 pub fn check_scripts_sequential(
-    sig_cache: &Cache<SigCacheKey, bool>,
     tx: &impl VerifiableTransaction,
-    covenants_ctx: CovenantsContext,
+    ctx: EngineContext<'_, SigHashReusedValuesUnsync>,
     flags: EngineFlags,
 ) -> TxResult<()> {
-    let reused_values = SigHashReusedValuesUnsync::new();
-    let ctx = EngineContext::with_covenants_ctx(&reused_values, sig_cache, &covenants_ctx);
     for (i, (input, entry)) in tx.populated_inputs().enumerate() {
         TxScriptEngine::from_transaction_input(tx, input, i, entry, ctx, flags).execute().map_err(|err| map_script_err(err, input))?;
     }
@@ -286,13 +271,10 @@ pub fn check_scripts_sequential(
 }
 
 pub fn check_scripts_par_iter(
-    sig_cache: &Cache<SigCacheKey, bool>,
     tx: &(impl VerifiableTransaction + Sync),
-    covenants_ctx: CovenantsContext,
+    ctx: EngineContext<'_, SigHashReusedValuesSync>,
     flags: EngineFlags,
 ) -> TxResult<()> {
-    let reused_values = SigHashReusedValuesSync::new();
-    let ctx = EngineContext::with_covenants_ctx(&reused_values, sig_cache, &covenants_ctx);
     (0..tx.inputs().len()).into_par_iter().try_for_each(|idx| {
         let (input, utxo) = tx.populated_input(idx);
         TxScriptEngine::from_transaction_input(tx, input, idx, utxo, ctx, flags).execute().map_err(|err| map_script_err(err, input))
@@ -300,13 +282,12 @@ pub fn check_scripts_par_iter(
 }
 
 pub fn check_scripts_par_iter_pool(
-    sig_cache: &Cache<SigCacheKey, bool>,
     tx: &(impl VerifiableTransaction + Sync),
-    covenants_ctx: CovenantsContext,
-    pool: &ThreadPool,
+    ctx: EngineContext<'_, SigHashReusedValuesSync>,
     flags: EngineFlags,
+    pool: &ThreadPool,
 ) -> TxResult<()> {
-    pool.install(|| check_scripts_par_iter(sig_cache, tx, covenants_ctx, flags))
+    pool.install(|| check_scripts_par_iter(tx, ctx, flags))
 }
 
 fn map_script_err(script_err: TxScriptError, input: &TransactionInput) -> TxRuleError {
@@ -411,13 +392,13 @@ mod tests {
         );
 
         let flags = Default::default();
-        tv.check_scripts(&populated_tx, flags).expect("Signature check failed");
+        tv.check_scripts(&populated_tx, Default::default(), flags).expect("Signature check failed");
 
         // Test a tx with 2 inputs to cover parallelism split points in inner script checking code
         let (tx2, entries2) = duplicate_input(&tx, &populated_tx.entries);
         // Duplicated sigs should fail due to wrong sighash
         assert_eq!(
-            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), flags),
+            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), Default::default(), flags),
             Err(TxRuleError::SignatureInvalid(TxScriptError::EvalFalse))
         );
     }
@@ -491,11 +472,12 @@ mod tests {
         );
 
         let flags = Default::default();
-        assert!(tv.check_scripts(&populated_tx, flags).is_err(), "Expecting signature check to fail");
+        assert!(tv.check_scripts(&populated_tx, Default::default(), flags).is_err(), "Expecting signature check to fail");
 
         // Test a tx with 2 inputs to cover parallelism split points in inner script checking code
         let (tx2, entries2) = duplicate_input(&tx, &populated_tx.entries);
-        tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), flags).expect_err("Expecting signature check to fail");
+        tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), Default::default(), flags)
+            .expect_err("Expecting signature check to fail");
 
         // Verify we are correctly testing the parallelism case (applied here as sanity for all tests)
         assert!(
@@ -575,13 +557,13 @@ mod tests {
         );
 
         let flags = Default::default();
-        tv.check_scripts(&populated_tx, flags).expect("Signature check failed");
+        tv.check_scripts(&populated_tx, Default::default(), flags).expect("Signature check failed");
 
         // Test a tx with 2 inputs to cover parallelism split points in inner script checking code
         let (tx2, entries2) = duplicate_input(&tx, &populated_tx.entries);
         // Duplicated sigs should fail due to wrong sighash
         assert_eq!(
-            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), flags),
+            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), Default::default(), flags),
             Err(TxRuleError::SignatureInvalid(TxScriptError::NullFail))
         );
     }
@@ -656,12 +638,15 @@ mod tests {
         );
 
         let flags = Default::default();
-        assert_eq!(tv.check_scripts(&populated_tx, flags), Err(TxRuleError::SignatureInvalid(TxScriptError::NullFail)));
+        assert_eq!(
+            tv.check_scripts(&populated_tx, Default::default(), flags),
+            Err(TxRuleError::SignatureInvalid(TxScriptError::NullFail))
+        );
 
         // Test a tx with 2 inputs to cover parallelism split points in inner script checking code
         let (tx2, entries2) = duplicate_input(&tx, &populated_tx.entries);
         assert_eq!(
-            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), flags),
+            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), Default::default(), flags),
             Err(TxRuleError::SignatureInvalid(TxScriptError::NullFail))
         );
     }
@@ -736,12 +721,15 @@ mod tests {
         );
 
         let flags = Default::default();
-        assert_eq!(tv.check_scripts(&populated_tx, flags), Err(TxRuleError::SignatureInvalid(TxScriptError::NullFail)));
+        assert_eq!(
+            tv.check_scripts(&populated_tx, Default::default(), flags),
+            Err(TxRuleError::SignatureInvalid(TxScriptError::NullFail))
+        );
 
         // Test a tx with 2 inputs to cover parallelism split points in inner script checking code
         let (tx2, entries2) = duplicate_input(&tx, &populated_tx.entries);
         assert_eq!(
-            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), flags),
+            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), Default::default(), flags),
             Err(TxRuleError::SignatureInvalid(TxScriptError::NullFail))
         );
     }
@@ -816,12 +804,15 @@ mod tests {
         );
 
         let flags = Default::default();
-        assert_eq!(tv.check_scripts(&populated_tx, flags), Err(TxRuleError::SignatureInvalid(TxScriptError::EvalFalse)));
+        assert_eq!(
+            tv.check_scripts(&populated_tx, Default::default(), flags),
+            Err(TxRuleError::SignatureInvalid(TxScriptError::EvalFalse))
+        );
 
         // Test a tx with 2 inputs to cover parallelism split points in inner script checking code
         let (tx2, entries2) = duplicate_input(&tx, &populated_tx.entries);
         assert_eq!(
-            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), flags),
+            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), Default::default(), flags),
             Err(TxRuleError::SignatureInvalid(TxScriptError::EvalFalse))
         );
     }
@@ -884,14 +875,14 @@ mod tests {
 
         let flags = Default::default();
         assert_eq!(
-            tv.check_scripts(&populated_tx, flags),
+            tv.check_scripts(&populated_tx, Default::default(), flags),
             Err(TxRuleError::SignatureInvalid(TxScriptError::SignatureScriptNotPushOnly))
         );
 
         // Test a tx with 2 inputs to cover parallelism split points in inner script checking code
         let (tx2, entries2) = duplicate_input(&tx, &populated_tx.entries);
         assert_eq!(
-            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), flags),
+            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), Default::default(), flags),
             Err(TxRuleError::SignatureInvalid(TxScriptError::SignatureScriptNotPushOnly))
         );
     }
@@ -983,7 +974,7 @@ mod tests {
         let schnorr_key = secp256k1::Keypair::from_seckey_slice(secp256k1::SECP256K1, &secret_key.secret_bytes()).unwrap();
         let signed_tx = sign(MutableTransaction::with_entries(unsigned_tx, entries), schnorr_key);
         let populated_tx = signed_tx.as_verifiable();
-        assert_eq!(tv.check_scripts(&populated_tx, Default::default()), Ok(()));
+        assert_eq!(tv.check_scripts(&populated_tx, Default::default(), Default::default()), Ok(()));
         assert_eq!(TransactionValidator::check_sig_op_counts(&populated_tx), Ok(()));
     }
 }

--- a/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
@@ -5,7 +5,7 @@ use kaspa_consensus_core::{
 };
 use kaspa_txscript::{
     covenants::{CovenantGlobalContext, CovenantLocalContext, CovenantsContext},
-    get_sig_op_count_upper_bound, EngineContext, EngineFlags, MissingReusedValues, TxScriptEngine,
+    get_sig_op_count_upper_bound, EngineContext, EngineFlags, MissingReusedValues, SeqCommitAccessor, TxScriptEngine,
 };
 use kaspa_txscript_errors::TxScriptError;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -41,6 +41,7 @@ impl TransactionValidator {
         block_daa_score: u64,
         flags: TxValidationFlags,
         mass_and_feerate_threshold: Option<(u64, f64)>,
+        seq_commit_accessor: Option<&dyn SeqCommitAccessor>,
     ) -> TxResult<u64> {
         self.check_transaction_coinbase_maturity(tx, pov_daa_score)?;
         let total_in = self.check_transaction_input_amounts(tx)?;
@@ -58,7 +59,7 @@ impl TransactionValidator {
 
         match flags {
             TxValidationFlags::Full | TxValidationFlags::SkipMassCheck => {
-                self.check_scripts(tx, covenants_ctx, block_daa_score)?;
+                self.check_scripts(tx, covenants_ctx, block_daa_score, seq_commit_accessor)?;
             }
             TxValidationFlags::SkipScriptChecks => {}
         }
@@ -175,8 +176,11 @@ impl TransactionValidator {
         tx: &(impl VerifiableTransaction + Sync),
         covenants_ctx: CovenantsContext,
         block_daa_score: u64,
+        seq_commit_accessor: Option<&dyn SeqCommitAccessor>,
     ) -> TxResult<()> {
-        let ctx = EngineContext::with_missing(&self.sig_cache).with_covenants_ctx(&covenants_ctx);
+        let ctx = EngineContext::with_missing(&self.sig_cache)
+            .with_covenants_ctx(&covenants_ctx)
+            .with_seq_commit_accessor_opt(seq_commit_accessor);
         let flags = EngineFlags { covenants_enabled: self.covenants_activation.is_active(block_daa_score) };
         check_scripts(tx, ctx, flags)
     }
@@ -392,13 +396,13 @@ mod tests {
         );
 
         let flags = Default::default();
-        tv.check_scripts(&populated_tx, Default::default(), flags).expect("Signature check failed");
+        tv.check_scripts(&populated_tx, Default::default(), flags, None).expect("Signature check failed");
 
         // Test a tx with 2 inputs to cover parallelism split points in inner script checking code
         let (tx2, entries2) = duplicate_input(&tx, &populated_tx.entries);
         // Duplicated sigs should fail due to wrong sighash
         assert_eq!(
-            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), Default::default(), flags),
+            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), Default::default(), flags, None),
             Err(TxRuleError::SignatureInvalid(TxScriptError::EvalFalse))
         );
     }
@@ -472,11 +476,11 @@ mod tests {
         );
 
         let flags = Default::default();
-        assert!(tv.check_scripts(&populated_tx, Default::default(), flags).is_err(), "Expecting signature check to fail");
+        assert!(tv.check_scripts(&populated_tx, Default::default(), flags, None).is_err(), "Expecting signature check to fail");
 
         // Test a tx with 2 inputs to cover parallelism split points in inner script checking code
         let (tx2, entries2) = duplicate_input(&tx, &populated_tx.entries);
-        tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), Default::default(), flags)
+        tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), Default::default(), flags, None)
             .expect_err("Expecting signature check to fail");
 
         // Verify we are correctly testing the parallelism case (applied here as sanity for all tests)
@@ -557,13 +561,13 @@ mod tests {
         );
 
         let flags = Default::default();
-        tv.check_scripts(&populated_tx, Default::default(), flags).expect("Signature check failed");
+        tv.check_scripts(&populated_tx, Default::default(), flags, None).expect("Signature check failed");
 
         // Test a tx with 2 inputs to cover parallelism split points in inner script checking code
         let (tx2, entries2) = duplicate_input(&tx, &populated_tx.entries);
         // Duplicated sigs should fail due to wrong sighash
         assert_eq!(
-            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), Default::default(), flags),
+            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), Default::default(), flags, None),
             Err(TxRuleError::SignatureInvalid(TxScriptError::NullFail))
         );
     }
@@ -639,14 +643,14 @@ mod tests {
 
         let flags = Default::default();
         assert_eq!(
-            tv.check_scripts(&populated_tx, Default::default(), flags),
+            tv.check_scripts(&populated_tx, Default::default(), flags, None),
             Err(TxRuleError::SignatureInvalid(TxScriptError::NullFail))
         );
 
         // Test a tx with 2 inputs to cover parallelism split points in inner script checking code
         let (tx2, entries2) = duplicate_input(&tx, &populated_tx.entries);
         assert_eq!(
-            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), Default::default(), flags),
+            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), Default::default(), flags, None),
             Err(TxRuleError::SignatureInvalid(TxScriptError::NullFail))
         );
     }
@@ -722,14 +726,14 @@ mod tests {
 
         let flags = Default::default();
         assert_eq!(
-            tv.check_scripts(&populated_tx, Default::default(), flags),
+            tv.check_scripts(&populated_tx, Default::default(), flags, None),
             Err(TxRuleError::SignatureInvalid(TxScriptError::NullFail))
         );
 
         // Test a tx with 2 inputs to cover parallelism split points in inner script checking code
         let (tx2, entries2) = duplicate_input(&tx, &populated_tx.entries);
         assert_eq!(
-            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), Default::default(), flags),
+            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), Default::default(), flags, None),
             Err(TxRuleError::SignatureInvalid(TxScriptError::NullFail))
         );
     }
@@ -805,14 +809,14 @@ mod tests {
 
         let flags = Default::default();
         assert_eq!(
-            tv.check_scripts(&populated_tx, Default::default(), flags),
+            tv.check_scripts(&populated_tx, Default::default(), flags, None),
             Err(TxRuleError::SignatureInvalid(TxScriptError::EvalFalse))
         );
 
         // Test a tx with 2 inputs to cover parallelism split points in inner script checking code
         let (tx2, entries2) = duplicate_input(&tx, &populated_tx.entries);
         assert_eq!(
-            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), Default::default(), flags),
+            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), Default::default(), flags, None),
             Err(TxRuleError::SignatureInvalid(TxScriptError::EvalFalse))
         );
     }
@@ -875,14 +879,14 @@ mod tests {
 
         let flags = Default::default();
         assert_eq!(
-            tv.check_scripts(&populated_tx, Default::default(), flags),
+            tv.check_scripts(&populated_tx, Default::default(), flags, None),
             Err(TxRuleError::SignatureInvalid(TxScriptError::SignatureScriptNotPushOnly))
         );
 
         // Test a tx with 2 inputs to cover parallelism split points in inner script checking code
         let (tx2, entries2) = duplicate_input(&tx, &populated_tx.entries);
         assert_eq!(
-            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), Default::default(), flags),
+            tv.check_scripts(&PopulatedTransaction::new(&tx2, entries2), Default::default(), flags, None),
             Err(TxRuleError::SignatureInvalid(TxScriptError::SignatureScriptNotPushOnly))
         );
     }
@@ -974,7 +978,7 @@ mod tests {
         let schnorr_key = secp256k1::Keypair::from_seckey_slice(secp256k1::SECP256K1, &secret_key.secret_bytes()).unwrap();
         let signed_tx = sign(MutableTransaction::with_entries(unsigned_tx, entries), schnorr_key);
         let populated_tx = signed_tx.as_verifiable();
-        assert_eq!(tv.check_scripts(&populated_tx, Default::default(), Default::default()), Ok(()));
+        assert_eq!(tv.check_scripts(&populated_tx, Default::default(), Default::default(), None), Ok(()));
         assert_eq!(TransactionValidator::check_sig_op_counts(&populated_tx), Ok(()));
     }
 }

--- a/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
@@ -197,20 +197,20 @@ impl TransactionValidator {
         }
 
         for (i, output) in tx.outputs().iter().enumerate() {
-            if let Some(cov_out_info) = &output.cov_out_info {
-                let auth_input = cov_out_info.authorizing_input as usize;
+            if let Some(covenant) = &output.covenant {
+                let auth_input = covenant.authorizing_input as usize;
                 let Some(utxo_entry) = tx.utxo(auth_input) else {
                     // TODO: Change to another error
                     return Err(TxRuleError::MissingTxOutpoints);
                 };
                 if let Some(covenant_id) = utxo_entry.covenant_id {
-                    if covenant_id != cov_out_info.covenant_id {
+                    if covenant_id != covenant.covenant_id {
                         return Err(TxRuleError::WrongCovenantId(i));
                     }
                 } else {
                     let authorizing_input = &tx.inputs()[auth_input]; // Guaranteed to exist from the earlier check on the UTXO entry.
                     if kaspa_consensus_core::hashing::covenant_id::covenant_id(authorizing_input.previous_outpoint)
-                        != cov_out_info.covenant_id
+                        != covenant.covenant_id
                     {
                         return Err(TxRuleError::WrongCovenantId(i));
                     }
@@ -218,11 +218,11 @@ impl TransactionValidator {
 
                 ctx.input_ctxs
                     .entry(auth_input)
-                    .or_insert_with(|| CovenantInputContext::new(cov_out_info.covenant_id))
+                    .or_insert_with(|| CovenantInputContext::new(covenant.covenant_id))
                     .auth_outputs
                     .push(i);
 
-                ctx.shared_ctxs.entry(cov_out_info.covenant_id).or_default().output_indices.push(i);
+                ctx.shared_ctxs.entry(covenant.covenant_id).or_default().output_indices.push(i);
             }
         }
 
@@ -336,15 +336,11 @@ mod tests {
                 sig_op_count: 1,
             }],
             vec![
-                TransactionOutput {
-                    value: 10360487799,
-                    script_public_key: ScriptPublicKey::new(0, script_pub_key_2),
-                    cov_out_info: None,
-                },
+                TransactionOutput { value: 10360487799, script_public_key: ScriptPublicKey::new(0, script_pub_key_2), covenant: None },
                 TransactionOutput {
                     value: 10518958752,
                     script_public_key: ScriptPublicKey::new(0, script_pub_key_1.clone()),
-                    cov_out_info: None,
+                    covenant: None,
                 },
             ],
             0,
@@ -419,13 +415,9 @@ mod tests {
                 TransactionOutput {
                     value: 10360487799,
                     script_public_key: ScriptPublicKey::new(0, script_pub_key_2.clone()),
-                    cov_out_info: None,
+                    covenant: None,
                 },
-                TransactionOutput {
-                    value: 10518958752,
-                    script_public_key: ScriptPublicKey::new(0, script_pub_key_1),
-                    cov_out_info: None,
-                },
+                TransactionOutput { value: 10518958752, script_public_key: ScriptPublicKey::new(0, script_pub_key_1), covenant: None },
             ],
             0,
             SubnetworkId::from_bytes([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
@@ -504,12 +496,12 @@ mod tests {
                 TransactionOutput {
                     value: 10000000000000,
                     script_public_key: ScriptPublicKey::new(0, script_pub_key_2),
-                    cov_out_info: None,
+                    covenant: None,
                 },
                 TransactionOutput {
                     value: 2792999990000,
                     script_public_key: ScriptPublicKey::new(0, script_pub_key_1.clone()),
-                    cov_out_info: None,
+                    covenant: None,
                 },
             ],
             0,
@@ -585,12 +577,12 @@ mod tests {
                 TransactionOutput {
                     value: 10000000000000,
                     script_public_key: ScriptPublicKey::new(0, script_pub_key_2),
-                    cov_out_info: None,
+                    covenant: None,
                 },
                 TransactionOutput {
                     value: 2792999990000,
                     script_public_key: ScriptPublicKey::new(0, script_pub_key_1.clone()),
-                    cov_out_info: None,
+                    covenant: None,
                 },
             ],
             0,
@@ -668,12 +660,12 @@ mod tests {
                 TransactionOutput {
                     value: 10000000000000,
                     script_public_key: ScriptPublicKey::new(0, script_pub_key_2),
-                    cov_out_info: None,
+                    covenant: None,
                 },
                 TransactionOutput {
                     value: 2792999990000,
                     script_public_key: ScriptPublicKey::new(0, script_pub_key_1.clone()),
-                    cov_out_info: None,
+                    covenant: None,
                 },
             ],
             0,
@@ -751,12 +743,12 @@ mod tests {
                 TransactionOutput {
                     value: 10000000000000,
                     script_public_key: ScriptPublicKey::new(0, script_pub_key_2),
-                    cov_out_info: None,
+                    covenant: None,
                 },
                 TransactionOutput {
                     value: 2792999990000,
                     script_public_key: ScriptPublicKey::new(0, script_pub_key_1.clone()),
-                    cov_out_info: None,
+                    covenant: None,
                 },
             ],
             0,
@@ -827,7 +819,7 @@ mod tests {
             vec![TransactionOutput {
                 value: 2792999990000,
                 script_public_key: ScriptPublicKey::new(0, script_pub_key_1.clone()),
-                cov_out_info: None,
+                covenant: None,
             }],
             0,
             SubnetworkId::from_bytes([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
@@ -904,16 +896,8 @@ mod tests {
                 },
             ],
             vec![
-                TransactionOutput {
-                    value: 300,
-                    script_public_key: ScriptPublicKey::new(0, script_pub_key.clone()),
-                    cov_out_info: None,
-                },
-                TransactionOutput {
-                    value: 300,
-                    script_public_key: ScriptPublicKey::new(0, script_pub_key.clone()),
-                    cov_out_info: None,
-                },
+                TransactionOutput { value: 300, script_public_key: ScriptPublicKey::new(0, script_pub_key.clone()), covenant: None },
+                TransactionOutput { value: 300, script_public_key: ScriptPublicKey::new(0, script_pub_key.clone()), covenant: None },
             ],
             1615462089000,
             SubnetworkId::from_bytes([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),

--- a/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
@@ -10,7 +10,7 @@ use kaspa_txscript::{
 use kaspa_txscript_errors::TxScriptError;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rayon::ThreadPool;
-use std::{collections::hash_map::Entry, marker::Sync};
+use std::marker::Sync;
 
 use super::{
     errors::{TxResult, TxRuleError},
@@ -216,14 +216,11 @@ impl TransactionValidator {
                     }
                 }
 
-                match ctx.local_ctxs.entry(auth_input) {
-                    Entry::Occupied(mut e) => {
-                        e.get_mut().auth_outputs.push(i);
-                    }
-                    Entry::Vacant(e) => {
-                        e.insert(CovenantLocalContext { covenant_id: cov_out_info.covenant_id, auth_outputs: vec![i] });
-                    }
-                }
+                ctx.local_ctxs
+                    .entry(auth_input)
+                    .or_insert_with(|| CovenantLocalContext::new(cov_out_info.covenant_id))
+                    .auth_outputs
+                    .push(i);
 
                 ctx.covenant_ctxs.entry(cov_out_info.covenant_id).or_default().output_indices.push(i);
             }

--- a/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
@@ -4,7 +4,7 @@ use kaspa_consensus_core::{
     tx::{TransactionInput, VerifiableTransaction},
 };
 use kaspa_txscript::{
-    covenants::{CovenantGlobalContext, CovenantLocalContext, CovenantsContext},
+    covenants::{CovenantLocalContext, CovenantsContext},
     get_sig_op_count_upper_bound, EngineCtx, EngineCtxSync, EngineCtxUnsync, EngineFlags, SeqCommitAccessor, TxScriptEngine,
 };
 use kaspa_txscript_errors::TxScriptError;
@@ -192,14 +192,7 @@ impl TransactionValidator {
 
         for (i, (_, entry)) in tx.populated_inputs().enumerate() {
             if let Some(covenant_id) = entry.covenant_id {
-                match ctx.covenant_ctxs.entry(covenant_id) {
-                    Entry::Occupied(mut e) => {
-                        e.get_mut().input_indices.push(i);
-                    }
-                    Entry::Vacant(e) => {
-                        e.insert(CovenantGlobalContext { input_indices: vec![i], output_indices: Default::default() });
-                    }
-                }
+                ctx.covenant_ctxs.entry(covenant_id).or_default().input_indices.push(i);
             }
         }
 
@@ -232,14 +225,7 @@ impl TransactionValidator {
                     }
                 }
 
-                match ctx.covenant_ctxs.entry(cov_out_info.covenant_id) {
-                    Entry::Occupied(mut e) => {
-                        e.get_mut().output_indices.push(i);
-                    }
-                    Entry::Vacant(e) => {
-                        e.insert(CovenantGlobalContext { input_indices: Default::default(), output_indices: vec![i] });
-                    }
-                }
+                ctx.covenant_ctxs.entry(cov_out_info.covenant_id).or_default().output_indices.push(i);
             }
         }
 

--- a/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
@@ -4,8 +4,8 @@ use kaspa_consensus_core::{
     tx::{TransactionInput, VerifiableTransaction},
 };
 use kaspa_txscript::{
-    covenants::{CovenantInputContext, CovenantsContext},
-    get_sig_op_count_upper_bound, EngineCtx, EngineCtxSync, EngineCtxUnsync, EngineFlags, SeqCommitAccessor, TxScriptEngine,
+    covenants::CovenantsContext, get_sig_op_count_upper_bound, EngineCtx, EngineCtxSync, EngineCtxUnsync, EngineFlags,
+    SeqCommitAccessor, TxScriptEngine,
 };
 use kaspa_txscript_errors::TxScriptError;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -188,45 +188,7 @@ impl TransactionValidator {
             return Ok(Default::default());
         }
 
-        let mut ctx = CovenantsContext::default();
-
-        for (i, (_, entry)) in tx.populated_inputs().enumerate() {
-            if let Some(covenant_id) = entry.covenant_id {
-                ctx.shared_ctxs.entry(covenant_id).or_default().input_indices.push(i);
-            }
-        }
-
-        for (i, output) in tx.outputs().iter().enumerate() {
-            if let Some(covenant) = &output.covenant {
-                let auth_input = covenant.authorizing_input as usize;
-                let Some(utxo_entry) = tx.utxo(auth_input) else {
-                    // TODO: Change to another error
-                    return Err(TxRuleError::MissingTxOutpoints);
-                };
-                if let Some(covenant_id) = utxo_entry.covenant_id {
-                    if covenant_id != covenant.covenant_id {
-                        return Err(TxRuleError::WrongCovenantId(i));
-                    }
-                } else {
-                    let authorizing_input = &tx.inputs()[auth_input]; // Guaranteed to exist from the earlier check on the UTXO entry.
-                    if kaspa_consensus_core::hashing::covenant_id::covenant_id(authorizing_input.previous_outpoint)
-                        != covenant.covenant_id
-                    {
-                        return Err(TxRuleError::WrongCovenantId(i));
-                    }
-                }
-
-                ctx.input_ctxs
-                    .entry(auth_input)
-                    .or_insert_with(|| CovenantInputContext::new(covenant.covenant_id))
-                    .auth_outputs
-                    .push(i);
-
-                ctx.shared_ctxs.entry(covenant.covenant_id).or_default().output_indices.push(i);
-            }
-        }
-
-        Ok(ctx)
+        Ok(CovenantsContext::from_tx(tx)?)
     }
 }
 

--- a/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
@@ -4,7 +4,7 @@ use kaspa_consensus_core::{
     tx::{TransactionInput, VerifiableTransaction},
 };
 use kaspa_txscript::{
-    covenants::{CovenantLocalContext, CovenantsContext},
+    covenants::{CovenantInputContext, CovenantsContext},
     get_sig_op_count_upper_bound, EngineCtx, EngineCtxSync, EngineCtxUnsync, EngineFlags, SeqCommitAccessor, TxScriptEngine,
 };
 use kaspa_txscript_errors::TxScriptError;
@@ -192,7 +192,7 @@ impl TransactionValidator {
 
         for (i, (_, entry)) in tx.populated_inputs().enumerate() {
             if let Some(covenant_id) = entry.covenant_id {
-                ctx.covenant_ctxs.entry(covenant_id).or_default().input_indices.push(i);
+                ctx.shared_ctxs.entry(covenant_id).or_default().input_indices.push(i);
             }
         }
 
@@ -216,13 +216,13 @@ impl TransactionValidator {
                     }
                 }
 
-                ctx.local_ctxs
+                ctx.input_ctxs
                     .entry(auth_input)
-                    .or_insert_with(|| CovenantLocalContext::new(cov_out_info.covenant_id))
+                    .or_insert_with(|| CovenantInputContext::new(cov_out_info.covenant_id))
                     .auth_outputs
                     .push(i);
 
-                ctx.covenant_ctxs.entry(cov_out_info.covenant_id).or_default().output_indices.push(i);
+                ctx.shared_ctxs.entry(cov_out_info.covenant_id).or_default().output_indices.push(i);
             }
         }
 

--- a/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
+++ b/consensus/src/processes/transaction_validator/tx_validation_in_utxo_context.rs
@@ -5,7 +5,7 @@ use kaspa_consensus_core::{
 };
 use kaspa_txscript::{
     covenants::{CovenantGlobalContext, CovenantLocalContext, CovenantsContext},
-    get_sig_op_count_upper_bound, EngineContext, EngineFlags, MissingReusedValues, SeqCommitAccessor, TxScriptEngine,
+    get_sig_op_count_upper_bound, EngineCtx, EngineCtxSync, EngineCtxUnsync, EngineFlags, SeqCommitAccessor, TxScriptEngine,
 };
 use kaspa_txscript_errors::TxScriptError;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -178,9 +178,7 @@ impl TransactionValidator {
         block_daa_score: u64,
         seq_commit_accessor: Option<&dyn SeqCommitAccessor>,
     ) -> TxResult<()> {
-        let ctx = EngineContext::with_missing(&self.sig_cache)
-            .with_covenants_ctx(&covenants_ctx)
-            .with_seq_commit_accessor_opt(seq_commit_accessor);
+        let ctx = EngineCtx::new(&self.sig_cache).with_covenants_ctx(&covenants_ctx).with_seq_commit_accessor_opt(seq_commit_accessor);
         let flags = EngineFlags { covenants_enabled: self.covenants_activation.is_active(block_daa_score) };
         check_scripts(tx, ctx, flags)
     }
@@ -249,11 +247,7 @@ impl TransactionValidator {
     }
 }
 
-pub fn check_scripts(
-    tx: &(impl VerifiableTransaction + Sync),
-    ctx: EngineContext<'_, MissingReusedValues>,
-    flags: EngineFlags,
-) -> TxResult<()> {
+pub fn check_scripts(tx: &(impl VerifiableTransaction + Sync), ctx: EngineCtx<'_>, flags: EngineFlags) -> TxResult<()> {
     if tx.inputs().len() > CHECK_SCRIPTS_PARALLELISM_THRESHOLD {
         let reused_values = SigHashReusedValuesSync::new();
         check_scripts_par_iter(tx, ctx.with_reused(&reused_values), flags)
@@ -263,22 +257,14 @@ pub fn check_scripts(
     }
 }
 
-pub fn check_scripts_sequential(
-    tx: &impl VerifiableTransaction,
-    ctx: EngineContext<'_, SigHashReusedValuesUnsync>,
-    flags: EngineFlags,
-) -> TxResult<()> {
+pub fn check_scripts_sequential(tx: &impl VerifiableTransaction, ctx: EngineCtxUnsync<'_>, flags: EngineFlags) -> TxResult<()> {
     for (i, (input, entry)) in tx.populated_inputs().enumerate() {
         TxScriptEngine::from_transaction_input(tx, input, i, entry, ctx, flags).execute().map_err(|err| map_script_err(err, input))?;
     }
     Ok(())
 }
 
-pub fn check_scripts_par_iter(
-    tx: &(impl VerifiableTransaction + Sync),
-    ctx: EngineContext<'_, SigHashReusedValuesSync>,
-    flags: EngineFlags,
-) -> TxResult<()> {
+pub fn check_scripts_par_iter(tx: &(impl VerifiableTransaction + Sync), ctx: EngineCtxSync<'_>, flags: EngineFlags) -> TxResult<()> {
     (0..tx.inputs().len()).into_par_iter().try_for_each(|idx| {
         let (input, utxo) = tx.populated_input(idx);
         TxScriptEngine::from_transaction_input(tx, input, idx, utxo, ctx, flags).execute().map_err(|err| map_script_err(err, input))
@@ -287,7 +273,7 @@ pub fn check_scripts_par_iter(
 
 pub fn check_scripts_par_iter_pool(
     tx: &(impl VerifiableTransaction + Sync),
-    ctx: EngineContext<'_, SigHashReusedValuesSync>,
+    ctx: EngineCtxSync<'_>,
     flags: EngineFlags,
     pool: &ThreadPool,
 ) -> TxResult<()> {

--- a/crypto/hashes/Cargo.toml
+++ b/crypto/hashes/Cargo.toml
@@ -15,6 +15,7 @@ no-asm = ["keccak"]
 
 [dependencies]
 blake2b_simd.workspace = true
+blake3 = { workspace = true, features = ["default"] }
 borsh.workspace = true
 faster-hex.workspace = true
 js-sys.workspace = true

--- a/crypto/hashes/src/hashers.rs
+++ b/crypto/hashes/src/hashers.rs
@@ -37,6 +37,10 @@ sha256_hasher! {
     struct TransactionSigningHashECDSA => "TransactionSigningHashECDSA",
 }
 
+blake3_hasher! {
+    struct SeqCommitmentMerkleBranchHash => b"SeqCommitmentMerkleBranchHash",
+}
+
 macro_rules! sha256_hasher {
     ($(struct $name:ident => $domain_sep:literal),+ $(,)? ) => {$(
         #[derive(Clone)]
@@ -50,6 +54,7 @@ macro_rules! sha256_hasher {
                 // in the future we can replace this with the correct initial state.
                 static HASHER: Lazy<$name> = Lazy::new(|| {
                     // SHA256 doesn't natively support domain separation, so we hash it to make it constant size.
+                    // TODO: replace with Sha256::new_with_prefix() that does exactly this.
                     let mut tmp_state = Sha256::new();
                     tmp_state.update($domain_sep);
                     let mut out = $name(Sha256::new());
@@ -105,6 +110,43 @@ macro_rules! blake2b_hasher {
     impl_hasher!{ struct $name }
     )*};
 }
+
+macro_rules! blake3_hasher {
+    ($(struct $name:ident => $domain_sep:literal),+ $(,)? ) => {$(
+        #[derive(Clone)]
+        pub struct $name(blake3::Hasher);
+
+        impl $name {
+            #[inline(always)]
+            pub fn new() -> Self {
+                const KEY: [u8; blake3::KEY_LEN] = {
+                    let mut key = [0u8; blake3::KEY_LEN];
+                    let mut i = 0usize;
+                    while i < $domain_sep.len() {
+                        key[i] = $domain_sep[i];
+                        i += 1;
+                    }
+                    key
+                };
+
+                Self(blake3::Hasher::new_keyed(&KEY))
+            }
+
+            pub fn write<A: AsRef<[u8]>>(&mut self, data: A) {
+                self.0.update(data.as_ref());
+            }
+
+            #[inline(always)]
+            pub fn finalize(self) -> crate::Hash {
+                let mut out = [0u8; 32];
+                out.copy_from_slice(self.0.finalize().as_bytes());
+                crate::Hash(out)
+            }
+        }
+    impl_hasher!{ struct $name }
+    )*};
+}
+
 macro_rules! impl_hasher {
     (struct $name:ident) => {
         impl HasherBase for $name {
@@ -134,7 +176,7 @@ macro_rules! impl_hasher {
     };
 }
 
-use {blake2b_hasher, impl_hasher, sha256_hasher};
+use {blake2b_hasher, blake3_hasher, impl_hasher, sha256_hasher};
 
 #[cfg(test)]
 mod tests {

--- a/crypto/merkle/src/lib.rs
+++ b/crypto/merkle/src/lib.rs
@@ -1,11 +1,29 @@
-use kaspa_hashes::{Hash, HasherBase, MerkleBranchHash, ZERO_HASH};
+use kaspa_hashes::{Hash, Hasher, MerkleBranchHash, ZERO_HASH};
 
 pub fn calc_merkle_root(hashes: impl ExactSizeIterator<Item = Hash>) -> Hash {
-    if hashes.len() == 0 {
-        return ZERO_HASH;
+    calc_merkle_root_with_hasher::<MerkleBranchHash, false>(hashes)
+}
+
+pub fn merkle_hash(left: Hash, right: Hash) -> Hash {
+    merkle_hash_with_hasher(left, right, MerkleBranchHash::new())
+}
+
+pub fn merkle_hash_with_hasher(left: Hash, right: Hash, mut hasher: impl Hasher) -> Hash {
+    hasher.update(left).update(right);
+    hasher.finalize()
+}
+
+pub fn calc_merkle_root_with_hasher<H: Hasher, const USE_BRANCH_HASHER_FOR_SINGLE: bool>(
+    mut hashes: impl ExactSizeIterator<Item = Hash>,
+) -> Hash {
+    match hashes.len() {
+        0 => return cold_path_empty(),
+        1 if USE_BRANCH_HASHER_FOR_SINGLE => return merkle_hash_with_hasher(hashes.next().unwrap(), ZERO_HASH, H::default()),
+        _ => {}
     }
     let next_pot = hashes.len().next_power_of_two();
     let vec_len = 2 * next_pot - 1;
+
     let mut merkles = vec![None; vec_len];
     for (i, hash) in hashes.enumerate() {
         merkles[i] = Some(hash);
@@ -15,15 +33,124 @@ pub fn calc_merkle_root(hashes: impl ExactSizeIterator<Item = Hash>) -> Hash {
         if merkles[i].is_none() {
             merkles[offset] = None;
         } else {
-            merkles[offset] = Some(merkle_hash(merkles[i].unwrap(), merkles[i + 1].unwrap_or(ZERO_HASH)));
+            merkles[offset] = Some(merkle_hash_with_hasher(merkles[i].unwrap(), merkles[i + 1].unwrap_or(ZERO_HASH), H::default()));
         }
         offset += 1
     }
     merkles.last().unwrap().unwrap()
 }
 
-pub fn merkle_hash(left: Hash, right: Hash) -> Hash {
-    let mut hasher = MerkleBranchHash::new();
-    hasher.update(left).update(right);
-    hasher.finalize()
+#[inline(never)]
+#[cold]
+fn cold_path_empty() -> Hash {
+    ZERO_HASH
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kaspa_hashes::{HasherBase, SeqCommitmentMerkleBranchHash, TransactionHash};
+    use std::iter;
+    fn seq_comm_merkle_root(hashes: impl ExactSizeIterator<Item = Hash>) -> Hash {
+        calc_merkle_root_with_hasher::<SeqCommitmentMerkleBranchHash, true>(hashes)
+    }
+    fn make_hash(data: &[u8]) -> Hash {
+        let mut hasher = TransactionHash::new();
+        hasher.update(data);
+        hasher.finalize()
+    }
+    #[test]
+    fn test_empty_returns_zero_hash() {
+        let root = calc_merkle_root(std::iter::empty());
+        assert_eq!(root, ZERO_HASH, "Empty input should return ZERO_HASH");
+
+        let seq_root = seq_comm_merkle_root(std::iter::empty());
+        assert_eq!(seq_root, ZERO_HASH, "Empty input should return ZERO_HASH for seq_comm");
+    }
+
+    #[test]
+    fn test_single_entry_returns_hash() {
+        let entry = make_hash(b"single_entry");
+        let root = calc_merkle_root(iter::once(entry));
+        let expected = entry;
+        assert_eq!(root, expected);
+
+        let expected = merkle_hash_with_hasher(entry, ZERO_HASH, SeqCommitmentMerkleBranchHash::default());
+        let seq_comm_root = seq_comm_merkle_root(iter::once(entry));
+        assert_eq!(seq_comm_root, expected, "Single entry should return merkle hash of entry with ZERO_HASH");
+    }
+
+    #[test]
+    fn test_two_entries_returns_hash_of_both() {
+        let h1 = make_hash(b"entry1");
+        let h2 = make_hash(b"entry2");
+
+        let root = calc_merkle_root([h1, h2].into_iter());
+        let expected = merkle_hash(h1, h2);
+        assert_eq!(root, expected, "Two entries should hash directly together");
+
+        let seq_root = seq_comm_merkle_root([h1, h2].into_iter());
+        let seq_expected = merkle_hash_with_hasher(h1, h2, SeqCommitmentMerkleBranchHash::default());
+        assert_eq!(seq_root, seq_expected, "Two entries should hash directly together for seq_comm");
+    }
+
+    #[test]
+    fn test_three_entries() {
+        // Tree structure for 3 entries (next_pot = 4):
+        // Indices: [h1, h2, h3, None, ..., result]
+        // Level 0: h1, h2, h3, None
+        // Level 1: hash(h1,h2), hash(h3,ZERO)
+        // Level 2: hash(hash(h1,h2), hash(h3,ZERO))
+        let h1 = make_hash(b"h1");
+        let h2 = make_hash(b"h2");
+        let h3 = make_hash(b"h3");
+
+        let root = calc_merkle_root([h1, h2, h3].into_iter());
+
+        let left = merkle_hash(h1, h2);
+        let right = merkle_hash(h3, ZERO_HASH);
+        let expected = merkle_hash(left, right);
+
+        assert_eq!(root, expected, "Three entries should build correct tree");
+    }
+
+    #[test]
+    fn test_four_entries() {
+        // Tree structure for 4 entries (next_pot = 4):
+        // Level 0: h1, h2, h3, h4
+        // Level 1: hash(h1,h2), hash(h3,h4)
+        // Level 2: hash(hash(h1,h2), hash(h3,h4))
+        let h1 = make_hash(b"h1");
+        let h2 = make_hash(b"h2");
+        let h3 = make_hash(b"h3");
+        let h4 = make_hash(b"h4");
+
+        let root = calc_merkle_root([h1, h2, h3, h4].into_iter());
+
+        let left = merkle_hash(h1, h2);
+        let right = merkle_hash(h3, h4);
+        let expected = merkle_hash(left, right);
+
+        assert_eq!(root, expected, "Four entries should build correct balanced tree");
+    }
+    #[test]
+    fn test_consistency_multiple_calls() {
+        let hashes: Vec<Hash> = (0..5).map(|i| make_hash(&[i])).collect();
+
+        let root1 = calc_merkle_root(hashes.clone().into_iter());
+        let root2 = calc_merkle_root(hashes.clone().into_iter());
+
+        assert_eq!(root1, root2, "Multiple calls with same input should produce same result");
+    }
+
+    #[test]
+    fn test_order_matters() {
+        let h1 = make_hash(b"h1");
+        let h2 = make_hash(b"h2");
+
+        let root1 = calc_merkle_root([h1, h2].into_iter());
+        let root2 = calc_merkle_root([h2, h1].into_iter());
+
+        assert_ne!(root1, root2, "Order of hashes should matter");
+    }
 }

--- a/crypto/txscript/errors/src/lib.rs
+++ b/crypto/txscript/errors/src/lib.rs
@@ -8,6 +8,8 @@ pub enum TxScriptError {
     MalformedPush(usize, usize),
     #[error("transaction input {0} is out of bounds, should be non-negative below {1}")]
     InvalidInputIndex(i32, usize),
+    #[error("transaction input {0} is either out of bounds or has no associated covenant outputs")]
+    InvalidCovInputIndex(i32),
     #[error("combined stack size {0} > max allowed {1}")]
     StackSizeExceeded(usize, usize),
     #[error("attempt to execute invalid opcode {0}")]

--- a/crypto/txscript/errors/src/lib.rs
+++ b/crypto/txscript/errors/src/lib.rs
@@ -84,6 +84,14 @@ pub enum TxScriptError {
 
     #[error("{0} is not a valid covenant output index for input {1} with {2} covenant outputs")]
     InvalidCovOutIndex(usize, usize, usize),
+    #[error("blockhash must be exactly 32 bytes long, got {0} bytes instead")]
+    InvalidLengthOfBlockHash(usize),
+    #[error("block {0} not selected")]
+    BlockNotSelected(String),
+    #[error("block {0} already pruned")]
+    BlockAlreadyPruned(String),
+    #[error("block {0} is too deep")]
+    BlockIsTooDeep(String),
 }
 
 #[derive(Error, PartialEq, Eq, Debug, Clone, Copy)]

--- a/crypto/txscript/errors/src/lib.rs
+++ b/crypto/txscript/errors/src/lib.rs
@@ -99,3 +99,13 @@ pub enum SerializationError {
     #[error("Number exceeds {1} bytes: {0}")]
     NumberTooLong(i64, usize),
 }
+
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
+pub enum CovenantsError {
+    #[error("output #{0} covenant id does not correspond to the authorizing input covenant id")]
+    WrongCovenantId(usize),
+    #[error("output #{0} covenant id does not correspond to the authorizing input outpoint hashing (genesis case)")]
+    WrongGenesisCovenantId(usize),
+    #[error("output #{0} covenant authorizing input index {1} is out of bounds")]
+    AuthInputOutOfBounds(usize, u16),
+}

--- a/crypto/txscript/errors/src/lib.rs
+++ b/crypto/txscript/errors/src/lib.rs
@@ -92,6 +92,8 @@ pub enum TxScriptError {
     BlockAlreadyPruned(String),
     #[error("block {0} is too deep")]
     BlockIsTooDeep(String),
+    #[error("covenants error: {0}")]
+    CovenantsError(#[from] CovenantsError),
 }
 
 #[derive(Error, PartialEq, Eq, Debug, Clone, Copy)]

--- a/crypto/txscript/examples/covenant_id.rs
+++ b/crypto/txscript/examples/covenant_id.rs
@@ -4,18 +4,21 @@ use kaspa_consensus_core::hashing;
 use kaspa_consensus_core::hashing::sighash::SigHashReusedValuesUnsync;
 use kaspa_consensus_core::subnets::SubnetworkId;
 use kaspa_consensus_core::tx::{
-    CovOutInfo, PopulatedTransaction, ScriptPublicKey, Transaction, TransactionInput, TransactionOutpoint, TransactionOutput, UtxoEntry
+    CovOutInfo, PopulatedTransaction, ScriptPublicKey, Transaction, TransactionInput, TransactionOutpoint, TransactionOutput,
+    UtxoEntry,
 };
 use kaspa_hashes::Hash;
 use kaspa_txscript::caches::Cache;
 use kaspa_txscript::opcodes::codes::{
-    Op1, Op1Add, OpBin2Num, OpBlake2b, OpCat, OpCovOutputCount, OpCovOutputIdx, OpData8, OpData60, OpData61, OpData62, OpDrop, OpDup, OpEqual, OpEqualVerify, OpNum2Bin, OpSub, OpSwap, OpTrue, OpTxInputIndex, OpTxInputScriptSigLen, OpTxInputScriptSigSubstr, OpTxOutputSpkLen, OpTxOutputSpkSubstr, OpVerify, OpWithin
+    Op1, Op1Add, OpBin2Num, OpBlake2b, OpCat, OpCovOutputCount, OpCovOutputIdx, OpData60, OpData61, OpData62, OpData8, OpDrop, OpDup,
+    OpEqual, OpEqualVerify, OpNum2Bin, OpSub, OpSwap, OpTrue, OpTxInputIndex, OpTxInputScriptSigLen, OpTxInputScriptSigSubstr,
+    OpTxOutputSpkLen, OpTxOutputSpkSubstr, OpVerify, OpWithin,
 };
 use kaspa_txscript::pay_to_script_hash_script;
 use kaspa_txscript::script_builder::{ScriptBuilder, ScriptBuilderResult};
 use kaspa_txscript::{EngineFlags, TxScriptEngine};
 use kaspa_txscript_errors::TxScriptError;
-use rand::{RngCore, Rng,seq::SliceRandom, SeedableRng};
+use rand::{seq::SliceRandom, Rng, RngCore, SeedableRng};
 
 fn main() -> ScriptBuilderResult<()> {
     counter_state_in_spk()
@@ -59,8 +62,12 @@ fn counter_state_in_spk() -> ScriptBuilderResult<()> {
 
     println!("[COVENANT P2SH-WS] Attempting invalid spend (reuse previous state)");
     // We try to spend the last UTXO but provide the previous state with counter=2
-    let bad_tx =
-        build_spend_tx(&CovenantState { utxo_outpoint: state.utxo_outpoint, ..counter_2_state }, state.counter, &covenant_script, &mut rng);
+    let bad_tx = build_spend_tx(
+        &CovenantState { utxo_outpoint: state.utxo_outpoint, ..counter_2_state },
+        state.counter,
+        &covenant_script,
+        &mut rng,
+    );
     let err = run_vm(&bad_tx, &state.utxo_entry, &sig_cache, &reused_values, flags).expect_err("non-incrementing spend must fail");
     println!("[COVENANT P2SH-WS] Expected failure: {err:?}");
 
@@ -101,9 +108,11 @@ impl CovenantState {
 /// 2) The spend has exactly one authorized output.
 /// 3) The output script public key matches the same redeem script suffix and embeds the hash of (state+1) in the state slot.
 fn build_covenant_script() -> ScriptBuilderResult<Vec<u8>> {
-    let p2sh_prefix = [0,0, // Script version 0
-     kaspa_txscript::opcodes::codes::OpBlake2b,
-     kaspa_txscript::opcodes::codes::OpData32,
+    let p2sh_prefix = [
+        0,
+        0, // Script version 0
+        kaspa_txscript::opcodes::codes::OpBlake2b,
+        kaspa_txscript::opcodes::codes::OpData32,
     ];
     let p2sh_suffix = [kaspa_txscript::opcodes::codes::OpEqual];
 
@@ -147,19 +156,19 @@ fn build_covenant_script() -> ScriptBuilderResult<Vec<u8>> {
         // Add OpData8 prefix
         .add_data(&[OpData8])?
         .add_op(OpSwap)?
-        .add_op(OpCat)? 
+        .add_op(OpCat)?
 
 
         // Fetch the redeem script suffix (after the counter)
         .add_i64(0)? // Input index
         .add_i64(10)? // Start
-        .add_i64(0)? 
+        .add_i64(0)?
         .add_op(OpTxInputScriptSigLen)? // End
         .add_op(OpTxInputScriptSigSubstr)?
 
         // Reconstruct the expected redeem script with incremented counter
         .add_op(OpCat)?
-        
+
         // Hash the redeem script
         .add_op(OpBlake2b)?
 
@@ -175,9 +184,9 @@ fn build_covenant_script() -> ScriptBuilderResult<Vec<u8>> {
         .add_i64(0)?
         .add_op(OpCovOutputIdx)? // Output index
         .add_i64(0)? // Start
-        .add_i64(0)? 
-        .add_i64(0)? 
-        .add_op(OpCovOutputIdx)? 
+        .add_i64(0)?
+        .add_i64(0)?
+        .add_op(OpCovOutputIdx)?
         .add_op(OpTxOutputSpkLen)? // End
         .add_op(OpTxOutputSpkSubstr)?
         .add_op(OpEqual)?
@@ -190,11 +199,8 @@ fn build_spend_tx(state: &CovenantState, next_counter: u8, covenant_script: &[u8
     let sig_script = ScriptBuilder::new().add_data(&build_redeem_script(state.counter, covenant_script)).unwrap().drain();
 
     let input = TransactionInput::new(state.utxo_outpoint, sig_script, 0, 0);
-    let mut output = TransactionOutput::new(state.utxo_entry.amount-10, build_spk(next_counter, covenant_script));
-    output.cov_out_info = Some(CovOutInfo{
-        covenant_id: state.covenant_id,
-        authorizing_input: 0,
-    });
+    let mut output = TransactionOutput::new(state.utxo_entry.amount - 10, build_spk(next_counter, covenant_script));
+    output.cov_out_info = Some(CovOutInfo { covenant_id: state.covenant_id, authorizing_input: 0 });
 
     let mut outputs = vec![output];
 

--- a/crypto/txscript/examples/covenant_id.rs
+++ b/crypto/txscript/examples/covenant_id.rs
@@ -1,5 +1,3 @@
-use core::panic;
-
 use kaspa_consensus_core::hashing;
 use kaspa_consensus_core::hashing::sighash::SigHashReusedValuesUnsync;
 use kaspa_consensus_core::subnets::SubnetworkId;

--- a/crypto/txscript/examples/covenant_id.rs
+++ b/crypto/txscript/examples/covenant_id.rs
@@ -12,8 +12,8 @@ use kaspa_txscript::opcodes::codes::{
     OpEqual, OpEqualVerify, OpNum2Bin, OpSub, OpSwap, OpTrue, OpTxInputIndex, OpTxInputScriptSigLen, OpTxInputScriptSigSubstr,
     OpTxOutputSpkLen, OpTxOutputSpkSubstr, OpVerify, OpWithin,
 };
-use kaspa_txscript::pay_to_script_hash_script;
 use kaspa_txscript::script_builder::{ScriptBuilder, ScriptBuilderResult};
+use kaspa_txscript::{pay_to_script_hash_script, EngineContext};
 use kaspa_txscript::{EngineFlags, TxScriptEngine};
 use kaspa_txscript_errors::TxScriptError;
 use rand::{seq::SliceRandom, Rng, RngCore, SeedableRng};
@@ -226,7 +226,14 @@ fn run_vm(
     flags: EngineFlags,
 ) -> Result<(), TxScriptError> {
     let populated = PopulatedTransaction::new(tx, vec![utxo_entry.clone()]);
-    let mut vm = TxScriptEngine::from_transaction_input(&populated, &tx.inputs[0], 0, utxo_entry, reused_values, sig_cache, flags);
+    let mut vm = TxScriptEngine::from_transaction_input(
+        &populated,
+        &tx.inputs[0],
+        0,
+        utxo_entry,
+        EngineContext::new(reused_values, sig_cache),
+        flags,
+    );
     vm.execute()
 }
 

--- a/crypto/txscript/examples/covenant_id.rs
+++ b/crypto/txscript/examples/covenant_id.rs
@@ -13,7 +13,7 @@ use kaspa_txscript::opcodes::codes::{
     OpTxOutputSpkLen, OpTxOutputSpkSubstr, OpVerify, OpWithin,
 };
 use kaspa_txscript::script_builder::{ScriptBuilder, ScriptBuilderResult};
-use kaspa_txscript::{pay_to_script_hash_script, EngineContext};
+use kaspa_txscript::{pay_to_script_hash_script, EngineCtx};
 use kaspa_txscript::{EngineFlags, TxScriptEngine};
 use kaspa_txscript_errors::TxScriptError;
 use rand::{seq::SliceRandom, Rng, RngCore, SeedableRng};
@@ -231,7 +231,7 @@ fn run_vm(
         &tx.inputs[0],
         0,
         utxo_entry,
-        EngineContext::new(reused_values, sig_cache),
+        EngineCtx::new(sig_cache).with_reused(reused_values),
         flags,
     );
     vm.execute()

--- a/crypto/txscript/examples/covenant_id.rs
+++ b/crypto/txscript/examples/covenant_id.rs
@@ -2,7 +2,7 @@ use kaspa_consensus_core::hashing;
 use kaspa_consensus_core::hashing::sighash::SigHashReusedValuesUnsync;
 use kaspa_consensus_core::subnets::SubnetworkId;
 use kaspa_consensus_core::tx::{
-    CovOutInfo, PopulatedTransaction, ScriptPublicKey, Transaction, TransactionInput, TransactionOutpoint, TransactionOutput,
+    CovenantBinding, PopulatedTransaction, ScriptPublicKey, Transaction, TransactionInput, TransactionOutpoint, TransactionOutput,
     UtxoEntry,
 };
 use kaspa_hashes::Hash;
@@ -107,7 +107,7 @@ impl CovenantState {
 fn build_covenant_script() -> ScriptBuilderResult<Vec<u8>> {
     let p2sh_prefix = [
         0,
-        0, // Script version 0
+        0, // Script version 0 (two bytes)
         kaspa_txscript::opcodes::codes::OpBlake2b,
         kaspa_txscript::opcodes::codes::OpData32,
     ];
@@ -197,7 +197,7 @@ fn build_spend_tx(state: &CovenantState, next_counter: u8, covenant_script: &[u8
 
     let input = TransactionInput::new(state.utxo_outpoint, sig_script, 0, 0);
     let mut output = TransactionOutput::new(state.utxo_entry.amount - 10, build_spk(next_counter, covenant_script));
-    output.cov_out_info = Some(CovOutInfo { covenant_id: state.covenant_id, authorizing_input: 0 });
+    output.covenant = Some(CovenantBinding { covenant_id: state.covenant_id, authorizing_input: 0 });
 
     let mut outputs = vec![output];
 

--- a/crypto/txscript/examples/covenant_id.rs
+++ b/crypto/txscript/examples/covenant_id.rs
@@ -8,9 +8,8 @@ use kaspa_consensus_core::tx::{
 use kaspa_hashes::Hash;
 use kaspa_txscript::caches::Cache;
 use kaspa_txscript::opcodes::codes::{
-    Op1, Op1Add, OpBin2Num, OpBlake2b, OpCat, OpCovOutputCount, OpCovOutputIdx, OpData60, OpData61, OpData62, OpData8, OpDrop, OpDup,
-    OpEqual, OpEqualVerify, OpNum2Bin, OpSub, OpSwap, OpTrue, OpTxInputIndex, OpTxInputScriptSigLen, OpTxInputScriptSigSubstr,
-    OpTxOutputSpkLen, OpTxOutputSpkSubstr, OpVerify, OpWithin,
+    Op1Add, OpBlake2b, OpCat, OpCovOutputCount, OpCovOutputIdx, OpData62, OpData8, OpEqual, OpEqualVerify, OpNum2Bin, OpSwap, OpTrue,
+    OpTxInputIndex, OpTxInputScriptSigLen, OpTxInputScriptSigSubstr, OpTxOutputSpkLen, OpTxOutputSpkSubstr,
 };
 use kaspa_txscript::script_builder::{ScriptBuilder, ScriptBuilderResult};
 use kaspa_txscript::{pay_to_script_hash_script, EngineCtx};

--- a/crypto/txscript/examples/covenants.rs
+++ b/crypto/txscript/examples/covenants.rs
@@ -10,8 +10,8 @@ use kaspa_txscript::opcodes::codes::{
     Op1Add, OpBlake2bWithKey, OpCat, OpDup, OpEqual, OpEqualVerify, OpOutpointTxId, OpRot, OpTxInputIndex, OpTxInputSpk,
     OpTxOutputCount, OpTxOutputSpk, OpTxPayloadLen, OpTxPayloadSubstr,
 };
-use kaspa_txscript::pay_to_script_hash_script;
 use kaspa_txscript::script_builder::{ScriptBuilder, ScriptBuilderResult};
+use kaspa_txscript::{pay_to_script_hash_script, EngineContext};
 use kaspa_txscript::{EngineFlags, TxScriptEngine};
 use kaspa_txscript_errors::TxScriptError;
 
@@ -168,7 +168,14 @@ fn run_vm(
     flags: EngineFlags,
 ) -> Result<(), TxScriptError> {
     let populated = PopulatedTransaction::new(tx, vec![utxo_entry.clone()]);
-    let mut vm = TxScriptEngine::from_transaction_input(&populated, &tx.inputs[0], 0, utxo_entry, reused_values, sig_cache, flags);
+    let mut vm = TxScriptEngine::from_transaction_input(
+        &populated,
+        &tx.inputs[0],
+        0,
+        utxo_entry,
+        EngineContext::new(reused_values, sig_cache),
+        flags,
+    );
     vm.execute()
 }
 

--- a/crypto/txscript/examples/covenants.rs
+++ b/crypto/txscript/examples/covenants.rs
@@ -11,7 +11,7 @@ use kaspa_txscript::opcodes::codes::{
     OpTxOutputCount, OpTxOutputSpk, OpTxPayloadLen, OpTxPayloadSubstr,
 };
 use kaspa_txscript::script_builder::{ScriptBuilder, ScriptBuilderResult};
-use kaspa_txscript::{pay_to_script_hash_script, EngineContext};
+use kaspa_txscript::{pay_to_script_hash_script, EngineCtx};
 use kaspa_txscript::{EngineFlags, TxScriptEngine};
 use kaspa_txscript_errors::TxScriptError;
 
@@ -173,7 +173,7 @@ fn run_vm(
         &tx.inputs[0],
         0,
         utxo_entry,
-        EngineContext::new(reused_values, sig_cache),
+        EngineCtx::new(sig_cache).with_reused(reused_values),
         flags,
     );
     vm.execute()

--- a/crypto/txscript/examples/kip-10.rs
+++ b/crypto/txscript/examples/kip-10.rs
@@ -17,7 +17,7 @@ use kaspa_txscript::{
     },
     pay_to_address_script, pay_to_script_hash_script,
     script_builder::{ScriptBuilder, ScriptBuilderResult},
-    TxScriptEngine,
+    EngineContext, TxScriptEngine,
 };
 use kaspa_txscript_errors::TxScriptError::{EvalFalse, VerifyError};
 use rand::thread_rng;
@@ -60,6 +60,8 @@ fn threshold_scenario() -> ScriptBuilderResult<()> {
 
     // Prepare to reuse values for signature hashing
     let reused_values = SigHashReusedValuesUnsync::new();
+
+    let ctx = EngineContext::new(&reused_values, &sig_cache);
 
     // Create the script builder
     let mut builder = ScriptBuilder::new();
@@ -126,15 +128,7 @@ fn threshold_scenario() -> ScriptBuilderResult<()> {
         }
 
         let tx = tx.as_verifiable();
-        let mut vm = TxScriptEngine::from_transaction_input(
-            &tx,
-            &tx.inputs()[0],
-            0,
-            &utxo_entry,
-            &reused_values,
-            &sig_cache,
-            Default::default(),
-        );
+        let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, &utxo_entry, ctx, Default::default());
         assert_eq!(vm.execute(), Ok(()));
         println!("[STANDARD] Owner branch execution successful");
     }
@@ -144,15 +138,7 @@ fn threshold_scenario() -> ScriptBuilderResult<()> {
         println!("[STANDARD] Checking borrower branch");
         tx.inputs[0].signature_script = ScriptBuilder::new().add_op(OpFalse)?.add_data(&script)?.drain();
         let tx = PopulatedTransaction::new(&tx, vec![utxo_entry.clone()]);
-        let mut vm = TxScriptEngine::from_transaction_input(
-            &tx,
-            &tx.tx.inputs[0],
-            0,
-            &utxo_entry,
-            &reused_values,
-            &sig_cache,
-            Default::default(),
-        );
+        let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.tx.inputs[0], 0, &utxo_entry, ctx, Default::default());
         assert_eq!(vm.execute(), Ok(()));
         println!("[STANDARD] Borrower branch execution successful");
     }
@@ -163,15 +149,7 @@ fn threshold_scenario() -> ScriptBuilderResult<()> {
         // Less than threshold
         tx.outputs[0].value -= 1;
         let tx = PopulatedTransaction::new(&tx, vec![utxo_entry.clone()]);
-        let mut vm = TxScriptEngine::from_transaction_input(
-            &tx,
-            &tx.tx.inputs[0],
-            0,
-            &utxo_entry,
-            &reused_values,
-            &sig_cache,
-            Default::default(),
-        );
+        let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.tx.inputs[0], 0, &utxo_entry, ctx, Default::default());
         assert_eq!(vm.execute(), Err(EvalFalse));
         println!("[STANDARD] Borrower branch with threshold not reached failed as expected");
     }
@@ -269,6 +247,8 @@ fn threshold_scenario_limited_one_time() -> ScriptBuilderResult<()> {
     // Prepare to reuse values for signature hashing
     let reused_values = SigHashReusedValuesUnsync::new();
 
+    let ctx = EngineContext::new(&reused_values, &sig_cache);
+
     // Generate the script public key
     let spk = pay_to_script_hash_script(&script);
 
@@ -319,15 +299,7 @@ fn threshold_scenario_limited_one_time() -> ScriptBuilderResult<()> {
         }
 
         let tx = tx.as_verifiable();
-        let mut vm = TxScriptEngine::from_transaction_input(
-            &tx,
-            &tx.inputs()[0],
-            0,
-            &utxo_entry,
-            &reused_values,
-            &sig_cache,
-            Default::default(),
-        );
+        let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, &utxo_entry, ctx, Default::default());
         assert_eq!(vm.execute(), Ok(()));
         println!("[ONE-TIME] Owner branch execution successful");
     }
@@ -337,15 +309,7 @@ fn threshold_scenario_limited_one_time() -> ScriptBuilderResult<()> {
         println!("[ONE-TIME] Checking borrower branch");
         tx.inputs[0].signature_script = ScriptBuilder::new().add_op(OpFalse)?.add_data(&script)?.drain();
         let tx = PopulatedTransaction::new(&tx, vec![utxo_entry.clone()]);
-        let mut vm = TxScriptEngine::from_transaction_input(
-            &tx,
-            &tx.tx.inputs[0],
-            0,
-            &utxo_entry,
-            &reused_values,
-            &sig_cache,
-            Default::default(),
-        );
+        let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.tx.inputs[0], 0, &utxo_entry, ctx, Default::default());
         assert_eq!(vm.execute(), Ok(()));
         println!("[ONE-TIME] Borrower branch execution successful");
     }
@@ -356,15 +320,7 @@ fn threshold_scenario_limited_one_time() -> ScriptBuilderResult<()> {
         // Less than threshold
         tx.outputs[0].value -= 1;
         let tx = PopulatedTransaction::new(&tx, vec![utxo_entry.clone()]);
-        let mut vm = TxScriptEngine::from_transaction_input(
-            &tx,
-            &tx.tx.inputs[0],
-            0,
-            &utxo_entry,
-            &reused_values,
-            &sig_cache,
-            Default::default(),
-        );
+        let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.tx.inputs[0], 0, &utxo_entry, ctx, Default::default());
         assert_eq!(vm.execute(), Err(EvalFalse));
         println!("[ONE-TIME] Borrower branch with threshold not reached failed as expected");
     }
@@ -386,15 +342,8 @@ fn threshold_scenario_limited_one_time() -> ScriptBuilderResult<()> {
         wrong_tx.inputs[0].signature_script = ScriptBuilder::new().add_op(OpFalse)?.add_data(&script)?.drain();
 
         let wrong_tx = PopulatedTransaction::new(&wrong_tx, vec![utxo_entry.clone()]);
-        let mut vm = TxScriptEngine::from_transaction_input(
-            &wrong_tx,
-            &wrong_tx.tx.inputs[0],
-            0,
-            &utxo_entry,
-            &reused_values,
-            &sig_cache,
-            Default::default(),
-        );
+        let mut vm =
+            TxScriptEngine::from_transaction_input(&wrong_tx, &wrong_tx.tx.inputs[0], 0, &utxo_entry, ctx, Default::default());
         assert_eq!(vm.execute(), Err(VerifyError));
         println!("[ONE-TIME] Borrower branch with output going to wrong address failed as expected");
     }
@@ -453,6 +402,8 @@ fn threshold_scenario_limited_2_times() -> ScriptBuilderResult<()> {
     // Prepare to reuse values for signature hashing
     let reused_values = SigHashReusedValuesUnsync::new();
 
+    let ctx = EngineContext::new(&reused_values, &sig_cache);
+
     // Generate the script public key
     let spk = pay_to_script_hash_script(&two_times_script);
 
@@ -503,15 +454,7 @@ fn threshold_scenario_limited_2_times() -> ScriptBuilderResult<()> {
         }
 
         let tx = tx.as_verifiable();
-        let mut vm = TxScriptEngine::from_transaction_input(
-            &tx,
-            &tx.inputs()[0],
-            0,
-            &utxo_entry,
-            &reused_values,
-            &sig_cache,
-            Default::default(),
-        );
+        let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, &utxo_entry, ctx, Default::default());
         assert_eq!(vm.execute(), Ok(()));
         println!("[TWO-TIMES] Owner branch execution successful");
     }
@@ -521,15 +464,7 @@ fn threshold_scenario_limited_2_times() -> ScriptBuilderResult<()> {
         println!("[TWO-TIMES] Checking borrower branch (first borrowing)");
         tx.inputs[0].signature_script = ScriptBuilder::new().add_op(OpFalse)?.add_data(&two_times_script)?.drain();
         let tx = PopulatedTransaction::new(&tx, vec![utxo_entry.clone()]);
-        let mut vm = TxScriptEngine::from_transaction_input(
-            &tx,
-            &tx.tx.inputs[0],
-            0,
-            &utxo_entry,
-            &reused_values,
-            &sig_cache,
-            Default::default(),
-        );
+        let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.tx.inputs[0], 0, &utxo_entry, ctx, Default::default());
         assert_eq!(vm.execute(), Ok(()));
         println!("[TWO-TIMES] Borrower branch (first borrowing) execution successful");
     }
@@ -540,15 +475,7 @@ fn threshold_scenario_limited_2_times() -> ScriptBuilderResult<()> {
         // Less than threshold
         tx.outputs[0].value -= 1;
         let tx = PopulatedTransaction::new(&tx, vec![utxo_entry.clone()]);
-        let mut vm = TxScriptEngine::from_transaction_input(
-            &tx,
-            &tx.tx.inputs[0],
-            0,
-            &utxo_entry,
-            &reused_values,
-            &sig_cache,
-            Default::default(),
-        );
+        let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.tx.inputs[0], 0, &utxo_entry, ctx, Default::default());
         assert_eq!(vm.execute(), Err(EvalFalse));
         println!("[TWO-TIMES] Borrower branch with threshold not reached failed as expected");
     }
@@ -570,15 +497,8 @@ fn threshold_scenario_limited_2_times() -> ScriptBuilderResult<()> {
         wrong_tx.inputs[0].signature_script = ScriptBuilder::new().add_op(OpFalse)?.add_data(&two_times_script)?.drain();
 
         let wrong_tx = PopulatedTransaction::new(&wrong_tx, vec![utxo_entry.clone()]);
-        let mut vm = TxScriptEngine::from_transaction_input(
-            &wrong_tx,
-            &wrong_tx.tx.inputs[0],
-            0,
-            &utxo_entry,
-            &reused_values,
-            &sig_cache,
-            Default::default(),
-        );
+        let mut vm =
+            TxScriptEngine::from_transaction_input(&wrong_tx, &wrong_tx.tx.inputs[0], 0, &utxo_entry, ctx, Default::default());
         assert_eq!(vm.execute(), Err(VerifyError));
         println!("[TWO-TIMES] Borrower branch with output going to wrong address failed as expected");
     }
@@ -694,8 +614,7 @@ fn shared_secret_scenario() -> ScriptBuilderResult<()> {
             &tx.inputs()[0],
             0,
             &utxo_entry,
-            &reused_values,
-            &sig_cache,
+            EngineContext::new(&reused_values, &sig_cache),
             Default::default(),
         );
         assert_eq!(vm.execute(), Ok(()));
@@ -720,8 +639,7 @@ fn shared_secret_scenario() -> ScriptBuilderResult<()> {
             &tx.inputs()[0],
             0,
             &utxo_entry,
-            &reused_values,
-            &sig_cache,
+            EngineContext::new(&reused_values, &sig_cache),
             Default::default(),
         );
         assert_eq!(vm.execute(), Ok(()));
@@ -746,8 +664,7 @@ fn shared_secret_scenario() -> ScriptBuilderResult<()> {
             &tx.inputs()[0],
             0,
             &utxo_entry,
-            &reused_values,
-            &sig_cache,
+            EngineContext::new(&reused_values, &sig_cache),
             Default::default(),
         );
         assert_eq!(vm.execute(), Err(VerifyError));

--- a/crypto/txscript/examples/kip-10.rs
+++ b/crypto/txscript/examples/kip-10.rs
@@ -85,7 +85,7 @@ fn threshold_scenario() -> ScriptBuilderResult<()> {
     let input_value = 1000000000;
 
     // Create a transaction output
-    let output = TransactionOutput { value: 1000000000 + threshold as u64, script_public_key: spk.clone(), cov_out_info: None };
+    let output = TransactionOutput { value: 1000000000 + threshold as u64, script_public_key: spk.clone(), covenant: None };
 
     // Create a UTXO entry for the input
     let utxo_entry = UtxoEntry::new(input_value, spk, 0, false, None);
@@ -256,7 +256,7 @@ fn threshold_scenario_limited_one_time() -> ScriptBuilderResult<()> {
     let input_value = 1000000000;
 
     // Create a transaction output
-    let output = TransactionOutput { value: 1000000000 + threshold as u64, script_public_key: p2pk.clone(), cov_out_info: None };
+    let output = TransactionOutput { value: 1000000000 + threshold as u64, script_public_key: p2pk.clone(), covenant: None };
 
     // Create a UTXO entry for the input
     let utxo_entry = UtxoEntry::new(input_value, spk, 0, false, None);
@@ -411,7 +411,7 @@ fn threshold_scenario_limited_2_times() -> ScriptBuilderResult<()> {
     let input_value = 1000000000;
 
     // Create a transaction output
-    let output = TransactionOutput { value: 1000000000 + threshold as u64, script_public_key: p2sh_one_time, cov_out_info: None };
+    let output = TransactionOutput { value: 1000000000 + threshold as u64, script_public_key: p2sh_one_time, covenant: None };
 
     // Create a UTXO entry for the input
     let utxo_entry = UtxoEntry::new(input_value, spk, 0, false, None);
@@ -560,7 +560,7 @@ fn shared_secret_scenario() -> ScriptBuilderResult<()> {
     let input_value = 1000000000;
 
     // Create a transaction output
-    let output = TransactionOutput { value: input_value, script_public_key: spk.clone(), cov_out_info: None };
+    let output = TransactionOutput { value: input_value, script_public_key: spk.clone(), covenant: None };
 
     // Create a UTXO entry for the input
     let utxo_entry = UtxoEntry::new(input_value, spk, 0, false, None);

--- a/crypto/txscript/examples/kip-10.rs
+++ b/crypto/txscript/examples/kip-10.rs
@@ -17,7 +17,7 @@ use kaspa_txscript::{
     },
     pay_to_address_script, pay_to_script_hash_script,
     script_builder::{ScriptBuilder, ScriptBuilderResult},
-    EngineContext, TxScriptEngine,
+    EngineCtx, TxScriptEngine,
 };
 use kaspa_txscript_errors::TxScriptError::{EvalFalse, VerifyError};
 use rand::thread_rng;
@@ -61,7 +61,7 @@ fn threshold_scenario() -> ScriptBuilderResult<()> {
     // Prepare to reuse values for signature hashing
     let reused_values = SigHashReusedValuesUnsync::new();
 
-    let ctx = EngineContext::new(&reused_values, &sig_cache);
+    let ctx = EngineCtx::new(&sig_cache).with_reused(&reused_values);
 
     // Create the script builder
     let mut builder = ScriptBuilder::new();
@@ -247,7 +247,7 @@ fn threshold_scenario_limited_one_time() -> ScriptBuilderResult<()> {
     // Prepare to reuse values for signature hashing
     let reused_values = SigHashReusedValuesUnsync::new();
 
-    let ctx = EngineContext::new(&reused_values, &sig_cache);
+    let ctx = EngineCtx::new(&sig_cache).with_reused(&reused_values);
 
     // Generate the script public key
     let spk = pay_to_script_hash_script(&script);
@@ -402,7 +402,7 @@ fn threshold_scenario_limited_2_times() -> ScriptBuilderResult<()> {
     // Prepare to reuse values for signature hashing
     let reused_values = SigHashReusedValuesUnsync::new();
 
-    let ctx = EngineContext::new(&reused_values, &sig_cache);
+    let ctx = EngineCtx::new(&sig_cache).with_reused(&reused_values);
 
     // Generate the script public key
     let spk = pay_to_script_hash_script(&two_times_script);
@@ -614,7 +614,7 @@ fn shared_secret_scenario() -> ScriptBuilderResult<()> {
             &tx.inputs()[0],
             0,
             &utxo_entry,
-            EngineContext::new(&reused_values, &sig_cache),
+            EngineCtx::new(&sig_cache).with_reused(&reused_values),
             Default::default(),
         );
         assert_eq!(vm.execute(), Ok(()));
@@ -639,7 +639,7 @@ fn shared_secret_scenario() -> ScriptBuilderResult<()> {
             &tx.inputs()[0],
             0,
             &utxo_entry,
-            EngineContext::new(&reused_values, &sig_cache),
+            EngineCtx::new(&sig_cache).with_reused(&reused_values),
             Default::default(),
         );
         assert_eq!(vm.execute(), Ok(()));
@@ -664,7 +664,7 @@ fn shared_secret_scenario() -> ScriptBuilderResult<()> {
             &tx.inputs()[0],
             0,
             &utxo_entry,
-            EngineContext::new(&reused_values, &sig_cache),
+            EngineCtx::new(&sig_cache).with_reused(&reused_values),
             Default::default(),
         );
         assert_eq!(vm.execute(), Err(VerifyError));

--- a/crypto/txscript/src/covenants.rs
+++ b/crypto/txscript/src/covenants.rs
@@ -28,7 +28,7 @@ pub struct CovenantGlobalContext {
     pub output_indices: Vec<usize>,
 }
 
-/// Pre-computed cache mapping inputs and covenant IDs to their execution contexts.
+/// Pre-computed cache mapping inputs and covenant ids to their execution contexts.
 ///
 /// Enables O(1) access for covenant introspection opcodes.
 #[derive(Default)]

--- a/crypto/txscript/src/covenants.rs
+++ b/crypto/txscript/src/covenants.rs
@@ -1,0 +1,56 @@
+use kaspa_hashes::Hash;
+use kaspa_txscript_errors::TxScriptError;
+use std::{collections::HashMap, sync::LazyLock};
+
+/// Context for an input's specific authority over a subset of outputs.
+///
+/// Used by scripts to verify the state transitions they directly authorized
+/// (e.g., 1-to-N splits) without scanning unrelated outputs.
+pub struct CovenantLocalContext {
+    /// The covenant ID shared by this input and its authorized outputs.
+    pub covenant_id: Hash,
+
+    /// Indices of outputs that explicitly declare this input as their `authorizing_input`.
+    ///
+    /// This defines the input's direct "children" in the transaction.
+    pub auth_outputs: Vec<usize>,
+}
+
+/// Context for the transaction-wide state of a specific Covenant ID.
+///
+/// Used for verifying global invariants across all participants of the same covenant
+/// (e.g., merges, batching, or conservation of amounts).
+pub struct CovenantGlobalContext {
+    /// Indices of *all* inputs in the transaction carrying this `covenant_id`.
+    pub input_indices: Vec<usize>,
+
+    /// Indices of *all* outputs in the transaction carrying this `covenant_id`.
+    pub output_indices: Vec<usize>,
+}
+
+/// Pre-computed cache mapping inputs and covenant IDs to their execution contexts.
+///
+/// Enables O(1) access for covenant introspection opcodes.
+#[derive(Default)]
+pub struct CovenantsContext {
+    /// Maps an input index to its local authority context.
+    pub local_ctxs: HashMap<usize, CovenantLocalContext>,
+
+    /// Maps a covenant id to its global context.
+    pub covenant_ctxs: HashMap<Hash, CovenantGlobalContext>,
+}
+
+impl CovenantsContext {
+    /// Returns the absolute transaction output index for the K-th authorized output.
+    pub(crate) fn auth_output_index(&self, input_idx: usize, k: usize) -> Result<usize, TxScriptError> {
+        let auth_outputs = &self.local_ctxs.get(&input_idx).ok_or(TxScriptError::InvalidCovInputIndex(input_idx as i32))?.auth_outputs;
+        auth_outputs.get(k).copied().ok_or(TxScriptError::InvalidCovOutIndex(k, input_idx, auth_outputs.len()))
+    }
+
+    /// Returns the number of outputs authorized by this input.
+    pub(crate) fn num_auth_outputs(&self, input_idx: usize) -> Result<usize, TxScriptError> {
+        Ok(self.local_ctxs.get(&input_idx).ok_or(TxScriptError::InvalidCovInputIndex(input_idx as i32))?.auth_outputs.len())
+    }
+}
+
+pub static EMPTY_COV_CONTEXT: LazyLock<CovenantsContext> = LazyLock::new(CovenantsContext::default);

--- a/crypto/txscript/src/covenants.rs
+++ b/crypto/txscript/src/covenants.rs
@@ -1,4 +1,4 @@
-use kaspa_consensus_core::tx::VerifiableTransaction;
+use kaspa_consensus_core::tx::{CovenantBinding, VerifiableTransaction};
 use kaspa_hashes::Hash;
 use kaspa_txscript_errors::{CovenantsError, TxScriptError};
 use std::{collections::HashMap, sync::LazyLock};
@@ -74,30 +74,40 @@ impl CovenantsContext {
         }
 
         for (i, output) in tx.outputs().iter().enumerate() {
-            if let Some(binding) = &output.covenant {
-                let auth_input = binding.authorizing_input as usize;
-                let Some(utxo_entry) = tx.utxo(auth_input) else {
-                    return Err(CovenantsError::AuthInputOutOfBounds(i, binding.authorizing_input));
-                };
-                if let Some(covenant_id) = utxo_entry.covenant_id {
-                    if covenant_id != binding.covenant_id {
-                        return Err(CovenantsError::WrongCovenantId(i));
-                    }
+            let Some(CovenantBinding { covenant_id, authorizing_input }) = output.covenant else {
+                continue;
+            };
 
-                    // Add output to ctxs only in the non genesis case
+            let auth_input_idx = authorizing_input as usize;
+
+            let Some(utxo_entry) = tx.utxo(auth_input_idx) else {
+                return Err(CovenantsError::AuthInputOutOfBounds(i, authorizing_input));
+            };
+
+            match utxo_entry.covenant_id {
+                Some(input_covenant_id) if input_covenant_id == covenant_id => {
+                    // Non-genesis case: the authorizing input is already under a covenant.
+                    // Add the output to the input- and covenant-level contexts.
+
                     ctx.input_ctxs
-                        .entry(auth_input)
-                        .or_insert_with(|| CovenantInputContext::new(binding.covenant_id))
+                        .entry(auth_input_idx)
+                        .or_insert_with(|| CovenantInputContext::new(covenant_id))
                         .auth_outputs
                         .push(i);
 
-                    ctx.shared_ctxs.entry(binding.covenant_id).or_default().output_indices.push(i);
-                } else {
-                    // Check the possibility for covenant genesis case
-                    let authorizing_input = &tx.inputs()[auth_input]; // Guaranteed to exist from the earlier check on the UTXO entry.
-                    if kaspa_consensus_core::hashing::covenant_id::covenant_id(authorizing_input.previous_outpoint)
-                        != binding.covenant_id
-                    {
+                    ctx.shared_ctxs.entry(covenant_id).or_default().output_indices.push(i);
+                }
+                Some(_) => {
+                    return Err(CovenantsError::WrongCovenantId(i));
+                }
+                None => {
+                    // Genesis case: the authorizing input is not under a covenant yet.
+                    // No covenant script is expected to run at this point, so we only validate.
+
+                    let input = &tx.inputs()[auth_input_idx]; // safe: utxo(auth_input) existed above
+                    let expected_id = kaspa_consensus_core::hashing::covenant_id::covenant_id(input.previous_outpoint);
+
+                    if expected_id != covenant_id {
                         return Err(CovenantsError::WrongGenesisCovenantId(i));
                     }
                 }

--- a/crypto/txscript/src/covenants.rs
+++ b/crypto/txscript/src/covenants.rs
@@ -16,6 +16,12 @@ pub struct CovenantLocalContext {
     pub auth_outputs: Vec<usize>,
 }
 
+impl CovenantLocalContext {
+    pub fn new(covenant_id: Hash) -> Self {
+        Self { covenant_id, auth_outputs: Default::default() }
+    }
+}
+
 /// Context for the transaction-wide state of a specific Covenant ID.
 ///
 /// Used for verifying global invariants across all participants of the same covenant

--- a/crypto/txscript/src/covenants.rs
+++ b/crypto/txscript/src/covenants.rs
@@ -20,6 +20,7 @@ pub struct CovenantLocalContext {
 ///
 /// Used for verifying global invariants across all participants of the same covenant
 /// (e.g., merges, batching, or conservation of amounts).
+#[derive(Default)]
 pub struct CovenantGlobalContext {
     /// Indices of *all* inputs in the transaction carrying this `covenant_id`.
     pub input_indices: Vec<usize>,

--- a/crypto/txscript/src/covenants.rs
+++ b/crypto/txscript/src/covenants.rs
@@ -74,31 +74,33 @@ impl CovenantsContext {
         }
 
         for (i, output) in tx.outputs().iter().enumerate() {
-            if let Some(covenant) = &output.covenant {
-                let auth_input = covenant.authorizing_input as usize;
+            if let Some(binding) = &output.covenant {
+                let auth_input = binding.authorizing_input as usize;
                 let Some(utxo_entry) = tx.utxo(auth_input) else {
-                    return Err(CovenantsError::AuthInputOutOfBounds(i, covenant.authorizing_input));
+                    return Err(CovenantsError::AuthInputOutOfBounds(i, binding.authorizing_input));
                 };
                 if let Some(covenant_id) = utxo_entry.covenant_id {
-                    if covenant_id != covenant.covenant_id {
+                    if covenant_id != binding.covenant_id {
                         return Err(CovenantsError::WrongCovenantId(i));
                     }
+
+                    // Add output to ctxs only in the non genesis case
+                    ctx.input_ctxs
+                        .entry(auth_input)
+                        .or_insert_with(|| CovenantInputContext::new(binding.covenant_id))
+                        .auth_outputs
+                        .push(i);
+
+                    ctx.shared_ctxs.entry(binding.covenant_id).or_default().output_indices.push(i);
                 } else {
+                    // Check the possibility for covenant genesis case
                     let authorizing_input = &tx.inputs()[auth_input]; // Guaranteed to exist from the earlier check on the UTXO entry.
                     if kaspa_consensus_core::hashing::covenant_id::covenant_id(authorizing_input.previous_outpoint)
-                        != covenant.covenant_id
+                        != binding.covenant_id
                     {
                         return Err(CovenantsError::WrongGenesisCovenantId(i));
                     }
                 }
-
-                ctx.input_ctxs
-                    .entry(auth_input)
-                    .or_insert_with(|| CovenantInputContext::new(covenant.covenant_id))
-                    .auth_outputs
-                    .push(i);
-
-                ctx.shared_ctxs.entry(covenant.covenant_id).or_default().output_indices.push(i);
             }
         }
 

--- a/crypto/txscript/src/covenants.rs
+++ b/crypto/txscript/src/covenants.rs
@@ -1,5 +1,6 @@
+use kaspa_consensus_core::tx::VerifiableTransaction;
 use kaspa_hashes::Hash;
-use kaspa_txscript_errors::TxScriptError;
+use kaspa_txscript_errors::{CovenantsError, TxScriptError};
 use std::{collections::HashMap, sync::LazyLock};
 
 /// Context for an input's specific authority over a subset of outputs.
@@ -61,3 +62,46 @@ impl CovenantsContext {
 }
 
 pub static EMPTY_COV_CONTEXT: LazyLock<CovenantsContext> = LazyLock::new(CovenantsContext::default);
+
+impl CovenantsContext {
+    pub fn from_tx(tx: &impl VerifiableTransaction) -> Result<Self, CovenantsError> {
+        let mut ctx = CovenantsContext::default();
+
+        for (i, (_, entry)) in tx.populated_inputs().enumerate() {
+            if let Some(covenant_id) = entry.covenant_id {
+                ctx.shared_ctxs.entry(covenant_id).or_default().input_indices.push(i);
+            }
+        }
+
+        for (i, output) in tx.outputs().iter().enumerate() {
+            if let Some(covenant) = &output.covenant {
+                let auth_input = covenant.authorizing_input as usize;
+                let Some(utxo_entry) = tx.utxo(auth_input) else {
+                    return Err(CovenantsError::AuthInputOutOfBounds(i, covenant.authorizing_input));
+                };
+                if let Some(covenant_id) = utxo_entry.covenant_id {
+                    if covenant_id != covenant.covenant_id {
+                        return Err(CovenantsError::WrongCovenantId(i));
+                    }
+                } else {
+                    let authorizing_input = &tx.inputs()[auth_input]; // Guaranteed to exist from the earlier check on the UTXO entry.
+                    if kaspa_consensus_core::hashing::covenant_id::covenant_id(authorizing_input.previous_outpoint)
+                        != covenant.covenant_id
+                    {
+                        return Err(CovenantsError::WrongGenesisCovenantId(i));
+                    }
+                }
+
+                ctx.input_ctxs
+                    .entry(auth_input)
+                    .or_insert_with(|| CovenantInputContext::new(covenant.covenant_id))
+                    .auth_outputs
+                    .push(i);
+
+                ctx.shared_ctxs.entry(covenant.covenant_id).or_default().output_indices.push(i);
+            }
+        }
+
+        Ok(ctx)
+    }
+}

--- a/crypto/txscript/src/covenants.rs
+++ b/crypto/txscript/src/covenants.rs
@@ -6,7 +6,7 @@ use std::{collections::HashMap, sync::LazyLock};
 ///
 /// Used by scripts to verify the state transitions they directly authorized
 /// (e.g., 1-to-N splits) without scanning unrelated outputs.
-pub struct CovenantLocalContext {
+pub struct CovenantInputContext {
     /// The covenant ID shared by this input and its authorized outputs.
     pub covenant_id: Hash,
 
@@ -16,18 +16,18 @@ pub struct CovenantLocalContext {
     pub auth_outputs: Vec<usize>,
 }
 
-impl CovenantLocalContext {
+impl CovenantInputContext {
     pub fn new(covenant_id: Hash) -> Self {
         Self { covenant_id, auth_outputs: Default::default() }
     }
 }
 
-/// Context for the transaction-wide state of a specific Covenant ID.
+/// Context for the shared transaction-wide state of a specific Covenant ID.
 ///
 /// Used for verifying global invariants across all participants of the same covenant
 /// (e.g., merges, batching, or conservation of amounts).
 #[derive(Default)]
-pub struct CovenantGlobalContext {
+pub struct CovenantSharedContext {
     /// Indices of *all* inputs in the transaction carrying this `covenant_id`.
     pub input_indices: Vec<usize>,
 
@@ -41,22 +41,22 @@ pub struct CovenantGlobalContext {
 #[derive(Default)]
 pub struct CovenantsContext {
     /// Maps an input index to its local authority context.
-    pub local_ctxs: HashMap<usize, CovenantLocalContext>,
+    pub input_ctxs: HashMap<usize, CovenantInputContext>,
 
-    /// Maps a covenant id to its global context.
-    pub covenant_ctxs: HashMap<Hash, CovenantGlobalContext>,
+    /// Maps a covenant id to its shared transaction-wide context.
+    pub shared_ctxs: HashMap<Hash, CovenantSharedContext>,
 }
 
 impl CovenantsContext {
     /// Returns the absolute transaction output index for the K-th authorized output.
     pub(crate) fn auth_output_index(&self, input_idx: usize, k: usize) -> Result<usize, TxScriptError> {
-        let auth_outputs = &self.local_ctxs.get(&input_idx).ok_or(TxScriptError::InvalidCovInputIndex(input_idx as i32))?.auth_outputs;
+        let auth_outputs = &self.input_ctxs.get(&input_idx).ok_or(TxScriptError::InvalidCovInputIndex(input_idx as i32))?.auth_outputs;
         auth_outputs.get(k).copied().ok_or(TxScriptError::InvalidCovOutIndex(k, input_idx, auth_outputs.len()))
     }
 
     /// Returns the number of outputs authorized by this input.
     pub(crate) fn num_auth_outputs(&self, input_idx: usize) -> Result<usize, TxScriptError> {
-        Ok(self.local_ctxs.get(&input_idx).ok_or(TxScriptError::InvalidCovInputIndex(input_idx as i32))?.auth_outputs.len())
+        Ok(self.input_ctxs.get(&input_idx).ok_or(TxScriptError::InvalidCovInputIndex(input_idx as i32))?.auth_outputs.len())
     }
 }
 

--- a/crypto/txscript/src/covenants.rs
+++ b/crypto/txscript/src/covenants.rs
@@ -48,22 +48,29 @@ pub struct CovenantsContext {
     pub shared_ctxs: HashMap<Hash, CovenantSharedContext>,
 }
 
+pub static EMPTY_COV_CONTEXT: LazyLock<CovenantsContext> = LazyLock::new(CovenantsContext::default);
+
 impl CovenantsContext {
-    /// Returns the absolute transaction output index for the K-th authorized output.
+    /// Returns the absolute transaction output index of the k-th authorized output.
+    ///
+    /// Missing input contexts are treated as having zero authorized outputs.
     pub(crate) fn auth_output_index(&self, input_idx: usize, k: usize) -> Result<usize, TxScriptError> {
-        let auth_outputs = &self.input_ctxs.get(&input_idx).ok_or(TxScriptError::InvalidCovInputIndex(input_idx as i32))?.auth_outputs;
+        let auth_outputs = self.input_ctxs.get(&input_idx).map(|ctx| ctx.auth_outputs.as_slice()).unwrap_or(&[]);
         auth_outputs.get(k).copied().ok_or(TxScriptError::InvalidCovOutIndex(k, input_idx, auth_outputs.len()))
     }
 
     /// Returns the number of outputs authorized by this input.
+    ///
+    /// Missing input contexts are treated as having zero authorized outputs.
     pub(crate) fn num_auth_outputs(&self, input_idx: usize) -> Result<usize, TxScriptError> {
-        Ok(self.input_ctxs.get(&input_idx).ok_or(TxScriptError::InvalidCovInputIndex(input_idx as i32))?.auth_outputs.len())
+        Ok(self.input_ctxs.get(&input_idx).map_or(0, |ctx| ctx.auth_outputs.len()))
     }
-}
 
-pub static EMPTY_COV_CONTEXT: LazyLock<CovenantsContext> = LazyLock::new(CovenantsContext::default);
-
-impl CovenantsContext {
+    /// Constructs the covenants execution context for a transaction.
+    ///
+    /// Collects per-input and shared covenant relations from the transaction,
+    /// validating covenant bindings and handling both continuation and genesis
+    /// cases. Genesis outputs are validated but do not populate covenant contexts.
     pub fn from_tx(tx: &impl VerifiableTransaction) -> Result<Self, CovenantsError> {
         let mut ctx = CovenantsContext::default();
 

--- a/crypto/txscript/src/data_stack.rs
+++ b/crypto/txscript/src/data_stack.rs
@@ -1,6 +1,7 @@
 use crate::{TxScriptError, MAX_SCRIPT_ELEMENT_SIZE};
 use core::fmt::Debug;
 use core::iter;
+use kaspa_hashes::Hash;
 use kaspa_txscript_errors::SerializationError;
 use std::cmp::Ordering;
 use std::num::TryFromIntError;
@@ -245,6 +246,18 @@ impl OpcodeData<bool> for Vec<u8> {
             true => vec![1],
             false => vec![],
         })
+    }
+}
+
+impl OpcodeData<Hash> for Vec<u8> {
+    #[inline]
+    fn deserialize(&self, _: bool) -> Result<Hash, TxScriptError> {
+        Hash::try_from_slice(self).map_err(|_| TxScriptError::InvalidLengthOfBlockHash(self.len()))
+    }
+
+    #[inline]
+    fn serialize(from: &Hash) -> Result<Self, SerializationError> {
+        Ok(from.as_bytes().to_vec())
     }
 }
 

--- a/crypto/txscript/src/engine_context.rs
+++ b/crypto/txscript/src/engine_context.rs
@@ -1,7 +1,7 @@
 use crate::caches::Cache;
 use crate::covenants::{CovenantsContext, EMPTY_COV_CONTEXT};
 use crate::{SeqCommitAccessor, SigCacheKey};
-use kaspa_consensus_core::hashing::sighash::SigHashReusedValues;
+use kaspa_consensus_core::hashing::sighash::{SigHashReusedValues, SigHashReusedValuesSync, SigHashReusedValuesUnsync};
 
 /// Marker type indicating that sig-hash reused values have not been bound yet.
 #[derive(Default)]
@@ -9,7 +9,7 @@ pub struct MissingReusedValues;
 
 pub struct EngineContext<'a, Reused> {
     pub(crate) reused_values: &'a Reused,
-    pub(crate) sig_cache: &'a Cache<SigCacheKey, bool>,
+    pub(crate) sig_cache: &'a SigCache,
     pub(crate) covenants_ctx: &'a CovenantsContext,
     pub(crate) seq_commit_accessor: Option<&'a dyn SeqCommitAccessor>,
 }
@@ -34,18 +34,13 @@ impl<'a, Reused> EngineContext<'a, Reused> {
     }
 }
 
-impl<'a, Reused: SigHashReusedValues> EngineContext<'a, Reused> {
-    /// Create a context with bound reused values, using an empty covenants context.
-    pub fn new(reused_values: &'a Reused, sig_cache: &'a Cache<SigCacheKey, bool>) -> Self {
-        Self { reused_values, sig_cache, covenants_ctx: &EMPTY_COV_CONTEXT, seq_commit_accessor: None }
-    }
-}
+type SigCache = Cache<SigCacheKey, bool>;
 
 impl<'a> EngineContext<'a, MissingReusedValues> {
     const MISSING: MissingReusedValues = MissingReusedValues;
 
     /// Create a context without bound reused values, using an empty covenants context.
-    pub fn with_missing(sig_cache: &'a Cache<SigCacheKey, bool>) -> Self {
+    pub fn new(sig_cache: &'a SigCache) -> Self {
         Self { reused_values: &Self::MISSING, sig_cache, covenants_ctx: &EMPTY_COV_CONTEXT, seq_commit_accessor: None }
     }
 
@@ -63,3 +58,12 @@ impl<'a, Reused: SigHashReusedValues> Clone for EngineContext<'a, Reused> {
 }
 
 impl<'a, Reused: SigHashReusedValues> Copy for EngineContext<'a, Reused> {}
+
+/// Engine context before binding sig-hash reused values.
+pub type EngineCtx<'a> = EngineContext<'a, MissingReusedValues>;
+
+/// Engine context for parallel script checking (thread-safe reused values).
+pub type EngineCtxSync<'a> = EngineContext<'a, SigHashReusedValuesSync>;
+
+/// Engine context for sequential script checking (non-thread-safe reused values).
+pub type EngineCtxUnsync<'a> = EngineContext<'a, SigHashReusedValuesUnsync>;

--- a/crypto/txscript/src/engine_context.rs
+++ b/crypto/txscript/src/engine_context.rs
@@ -1,0 +1,65 @@
+use crate::caches::Cache;
+use crate::covenants::{CovenantsContext, EMPTY_COV_CONTEXT};
+use crate::{SeqCommitAccessor, SigCacheKey};
+use kaspa_consensus_core::hashing::sighash::SigHashReusedValues;
+
+/// Marker type indicating that sig-hash reused values have not been bound yet.
+#[derive(Default)]
+pub struct MissingReusedValues;
+
+pub struct EngineContext<'a, Reused> {
+    pub(crate) reused_values: &'a Reused,
+    pub(crate) sig_cache: &'a Cache<SigCacheKey, bool>,
+    pub(crate) covenants_ctx: &'a CovenantsContext,
+    pub(crate) seq_commit_accessor: Option<&'a dyn SeqCommitAccessor>,
+}
+
+impl<'a, Reused> EngineContext<'a, Reused> {
+    /// Attach a covenants context to an existing engine context.
+    pub fn with_covenants_ctx(mut self, covenants_ctx: &'a CovenantsContext) -> Self {
+        self.covenants_ctx = covenants_ctx;
+        self
+    }
+
+    #[inline]
+    pub fn with_seq_commit_accessor(mut self, seq_commit_accessor: &'a dyn SeqCommitAccessor) -> Self {
+        self.seq_commit_accessor = Some(seq_commit_accessor);
+        self
+    }
+
+    #[inline]
+    pub fn with_seq_commit_accessor_opt(mut self, seq_commit_accessor: Option<&'a dyn SeqCommitAccessor>) -> Self {
+        self.seq_commit_accessor = seq_commit_accessor;
+        self
+    }
+}
+
+impl<'a, Reused: SigHashReusedValues> EngineContext<'a, Reused> {
+    /// Create a context with bound reused values, using an empty covenants context.
+    pub fn new(reused_values: &'a Reused, sig_cache: &'a Cache<SigCacheKey, bool>) -> Self {
+        Self { reused_values, sig_cache, covenants_ctx: &EMPTY_COV_CONTEXT, seq_commit_accessor: None }
+    }
+}
+
+impl<'a> EngineContext<'a, MissingReusedValues> {
+    const MISSING: MissingReusedValues = MissingReusedValues;
+
+    /// Create a context without bound reused values, using an empty covenants context.
+    pub fn with_missing(sig_cache: &'a Cache<SigCacheKey, bool>) -> Self {
+        Self { reused_values: &Self::MISSING, sig_cache, covenants_ctx: &EMPTY_COV_CONTEXT, seq_commit_accessor: None }
+    }
+
+    /// Upgrade the context by binding concrete sig-hash reused values (one-way).
+    #[inline]
+    pub fn with_reused<New: SigHashReusedValues>(self, reused_values: &'a New) -> EngineContext<'a, New> {
+        EngineContext { reused_values, sig_cache: self.sig_cache, covenants_ctx: self.covenants_ctx, seq_commit_accessor: None }
+    }
+}
+
+impl<'a, Reused: SigHashReusedValues> Clone for EngineContext<'a, Reused> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, Reused: SigHashReusedValues> Copy for EngineContext<'a, Reused> {}

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -15,6 +15,8 @@ pub mod wasm;
 
 pub mod runtime_sig_op_counter;
 
+use std::ops::Deref;
+
 use crate::caches::Cache;
 use crate::covenants::{CovenantsContext, EMPTY_COV_CONTEXT};
 use crate::data_stack::Stack;
@@ -84,16 +86,49 @@ pub struct EngineFlags {
     pub covenants_enabled: bool,
 }
 
+pub struct EngineContext<'a, Reused: SigHashReusedValues> {
+    reused_values: &'a Reused,
+    sig_cache: &'a Cache<SigCacheKey, bool>,
+    covenants_ctx: &'a CovenantsContext,
+}
+
+impl<'a, Reused: SigHashReusedValues> EngineContext<'a, Reused> {
+    pub fn new(reused_values: &'a Reused, sig_cache: &'a Cache<SigCacheKey, bool>) -> Self {
+        Self { reused_values, sig_cache, covenants_ctx: &EMPTY_COV_CONTEXT }
+    }
+
+    pub fn with_covenants_ctx(
+        reused_values: &'a Reused,
+        sig_cache: &'a Cache<SigCacheKey, bool>,
+        covenants_ctx: &'a CovenantsContext,
+    ) -> Self {
+        Self { reused_values, sig_cache, covenants_ctx }
+    }
+}
+
+impl<'a, Reused: SigHashReusedValues> Clone for EngineContext<'a, Reused> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<'a, Reused: SigHashReusedValues> Copy for EngineContext<'a, Reused> {}
+
+impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> Deref for TxScriptEngine<'a, T, Reused> {
+    type Target = EngineContext<'a, Reused>;
+    fn deref(&self) -> &Self::Target {
+        &self.ctx
+    }
+}
+
 pub struct TxScriptEngine<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> {
     dstack: Stack,
     astack: Stack,
 
     script_source: ScriptSource<'a, T>,
 
-    // Outer caches for quicker calculation
-    reused_values: &'a Reused,
-    covenants_ctx: &'a CovenantsContext,
-    sig_cache: &'a Cache<SigCacheKey, bool>,
+    // Engine context for outer caches and various inner contexts
+    ctx: EngineContext<'a, Reused>,
 
     cond_stack: Vec<OpCond>, // Following if stacks, and whether it is running
 
@@ -141,19 +176,18 @@ fn parse_script<T: VerifiableTransaction, Reused: SigHashReusedValues>(
 /// * `Err(TxScriptError)` - If script execution fails or input index is invalid
 pub fn get_sig_op_count<T: VerifiableTransaction>(
     tx: &T,
-    covenants_ctx: &CovenantsContext,
     input_idx: usize,
+    covenants_ctx: &CovenantsContext,
 ) -> Result<u8, TxScriptError> {
     let sig_cache = Cache::new(0);
     let reused_values = SigHashReusedValuesUnsync::new();
-    let mut vm = TxScriptEngine::from_transaction_input_with_covenants(
+    let ctx = EngineContext::with_covenants_ctx(&reused_values, &sig_cache, covenants_ctx);
+    let mut vm = TxScriptEngine::from_transaction_input(
         tx,
         &tx.inputs()[input_idx],
         input_idx,
         tx.utxo(input_idx).ok_or_else(|| TxScriptError::InvalidInputIndex(input_idx as i32, tx.inputs().len()))?,
-        &reused_values,
-        &covenants_ctx,
-        &sig_cache,
+        ctx,
         Default::default(),
     );
     vm.execute()?;
@@ -237,14 +271,12 @@ pub fn is_unspendable<T: VerifiableTransaction, Reused: SigHashReusedValues>(scr
 }
 
 impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'a, T, Reused> {
-    pub fn new(reused_values: &'a Reused, sig_cache: &'a Cache<SigCacheKey, bool>, flags: EngineFlags) -> Self {
+    pub fn new(ctx: EngineContext<'a, Reused>, flags: EngineFlags) -> Self {
         Self {
             dstack: Self::new_stack(flags),
             astack: Self::new_stack(flags),
             script_source: ScriptSource::StandAloneScripts(vec![]),
-            reused_values,
-            covenants_ctx: &EMPTY_COV_CONTEXT,
-            sig_cache,
+            ctx,
             cond_stack: vec![],
             num_ops: 0,
             runtime_sig_op_counter: RuntimeSigOpCounter::new(u8::MAX),
@@ -277,42 +309,12 @@ impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'
     ///
     /// # Returns
     /// Script engine instance configured for the given input
-    pub fn from_transaction_input_with_covenants(
-        tx: &'a T,
-        input: &'a TransactionInput,
-        input_idx: usize,
-        utxo_entry: &'a UtxoEntry,
-        reused_values: &'a Reused,
-        covenants_ctx: &'a CovenantsContext,
-        sig_cache: &'a Cache<SigCacheKey, bool>,
-        flags: EngineFlags,
-    ) -> Self {
-        let script_public_key = utxo_entry.script_public_key.script();
-        // The script_public_key in P2SH is just validating the hash on the OpMultiSig script
-        // the user provides
-        let is_p2sh = ScriptClass::is_pay_to_script_hash(script_public_key);
-        assert!(input_idx < tx.tx().inputs.len());
-        Self {
-            dstack: Self::new_stack(flags),
-            astack: Self::new_stack(flags),
-            script_source: ScriptSource::TxInput { tx, input, idx: input_idx, utxo_entry, is_p2sh },
-            reused_values,
-            covenants_ctx,
-            sig_cache,
-            cond_stack: Default::default(),
-            num_ops: 0,
-            runtime_sig_op_counter: RuntimeSigOpCounter::new(input.sig_op_count),
-            flags,
-        }
-    }
-
     pub fn from_transaction_input(
         tx: &'a T,
         input: &'a TransactionInput,
         input_idx: usize,
         utxo_entry: &'a UtxoEntry,
-        reused_values: &'a Reused,
-        sig_cache: &'a Cache<SigCacheKey, bool>,
+        ctx: EngineContext<'a, Reused>,
         flags: EngineFlags,
     ) -> Self {
         let script_public_key = utxo_entry.script_public_key.script();
@@ -324,9 +326,7 @@ impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'
             dstack: Self::new_stack(flags),
             astack: Self::new_stack(flags),
             script_source: ScriptSource::TxInput { tx, input, idx: input_idx, utxo_entry, is_p2sh },
-            reused_values,
-            covenants_ctx: &EMPTY_COV_CONTEXT,
-            sig_cache,
+            ctx,
             cond_stack: Default::default(),
             num_ops: 0,
             runtime_sig_op_counter: RuntimeSigOpCounter::new(input.sig_op_count),
@@ -344,9 +344,7 @@ impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'
             dstack: Self::new_stack(flags),
             astack: Self::new_stack(flags),
             script_source: ScriptSource::StandAloneScripts(vec![script]),
-            reused_values,
-            covenants_ctx: &EMPTY_COV_CONTEXT,
-            sig_cache,
+            ctx: EngineContext::new(reused_values, sig_cache),
             cond_stack: Default::default(),
             num_ops: 0,
             // Runtime sig op counting is not needed for standalone scripts, only inputs have sig op count value
@@ -754,8 +752,7 @@ mod tests {
                 &input,
                 0,
                 &utxo_entry,
-                &reused_values,
-                &sig_cache,
+                EngineContext::new(&reused_values, &sig_cache),
                 Default::default(),
             );
             assert_eq!(vm.execute(), test.expected_result);
@@ -1321,8 +1318,7 @@ mod tests {
                 &tx.inputs()[0],
                 0,
                 &utxo_entry,
-                &reused_values,
-                &sig_cache,
+                EngineContext::new(&reused_values, &sig_cache),
                 Default::default(),
             );
 
@@ -1466,8 +1462,7 @@ mod bitcoind_tests {
                 &populated_tx.tx().inputs[0],
                 0,
                 &populated_tx.entries[0],
-                &reused_values,
-                &sig_cache,
+                EngineContext::new(&reused_values, &sig_cache),
                 flags,
             );
             vm.execute().map_err(UnifiedError::TxScriptError)

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -238,15 +238,42 @@ pub fn is_unspendable<T: VerifiableTransaction, Reused: SigHashReusedValues>(scr
     parse_script::<T, Reused>(script).enumerate().any(|(index, op)| op.is_err() || (index == 0 && op.unwrap().value() == OpReturn))
 }
 
-pub struct CovenantInputContext {
+/// Context for an input's specific authority over a subset of outputs.
+///
+/// Used by scripts to verify the state transitions they directly authorized
+/// (e.g., 1-to-N splits) without scanning unrelated outputs.
+pub struct CovenantLocalContext {
+    /// The covenant ID shared by this input and its authorized outputs.
     pub covenant_id: Hash,
+
+    /// Indices of outputs that explicitly declare this input as their `authorizing_input`.
+    ///
+    /// This defines the input's direct "children" in the transaction.
+    pub authorized_outputs: Vec<usize>,
+}
+
+/// Context for the transaction-wide state of a specific Covenant ID.
+///
+/// Used for verifying global invariants across all participants of the same covenant
+/// (e.g., merges, batching, or conservation of amounts).
+pub struct CovenantGlobalContext {
+    /// Indices of *all* inputs in the transaction carrying this `covenant_id`.
+    pub input_indices: Vec<usize>,
+
+    /// Indices of *all* outputs in the transaction carrying this `covenant_id`.
     pub output_indices: Vec<usize>,
 }
 
+/// Pre-computed cache mapping inputs and covenant IDs to their execution contexts.
+///
+/// Enables O(1) access for covenant introspection opcodes.
 #[derive(Default)]
 pub struct CovenantsContext {
-    pub per_input_ctx: HashMap<usize, CovenantInputContext>,
-    // TODO: per covenant map to both ins and outs
+    /// Maps an input index to its local authority context.
+    pub local_ctxs: HashMap<usize, CovenantLocalContext>,
+
+    /// Maps a covenant id to its global context.
+    pub covenant_ctxs: HashMap<Hash, CovenantGlobalContext>,
 }
 
 static EMPTY_CONTEXT: LazyLock<CovenantsContext> = LazyLock::new(|| CovenantsContext::default());
@@ -356,10 +383,10 @@ impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'
 
         let output_indices = &self
             .covenants_ctx
-            .per_input_ctx
+            .local_ctxs
             .get(&input_idx)
             .ok_or(TxScriptError::InvalidCovInputIndex(input_idx as i32))?
-            .output_indices;
+            .authorized_outputs;
         output_indices.get(authorized_idx).copied().ok_or(TxScriptError::InvalidCovOutIndex(
             authorized_idx,
             input_idx,
@@ -373,10 +400,10 @@ impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'
 
         Ok(self
             .covenants_ctx
-            .per_input_ctx
+            .local_ctxs
             .get(&input_idx)
             .ok_or(TxScriptError::InvalidCovInputIndex(input_idx as i32))?
-            .output_indices
+            .authorized_outputs
             .len())
     }
 

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -2,6 +2,7 @@ extern crate alloc;
 extern crate core;
 
 pub mod caches;
+pub mod covenants;
 mod data_stack;
 pub mod error;
 pub mod opcodes;
@@ -14,10 +15,8 @@ pub mod wasm;
 
 pub mod runtime_sig_op_counter;
 
-use std::collections::HashMap;
-use std::sync::LazyLock;
-
 use crate::caches::Cache;
+use crate::covenants::{CovenantsContext, EMPTY_COV_CONTEXT};
 use crate::data_stack::Stack;
 use crate::opcodes::{deserialize_next_opcode, OpCodeImplementation};
 use itertools::Itertools;
@@ -26,10 +25,8 @@ use kaspa_consensus_core::hashing::sighash::{
 };
 use kaspa_consensus_core::hashing::sighash_type::SigHashType;
 use kaspa_consensus_core::tx::{ScriptPublicKey, TransactionInput, UtxoEntry, VerifiableTransaction};
-use kaspa_hashes::Hash;
 use kaspa_txscript_errors::TxScriptError;
 use log::trace;
-use once_cell::unsync::Lazy;
 use opcodes::codes::OpReturn;
 use opcodes::{codes, to_small_int, OpCond};
 use script_class::ScriptClass;
@@ -149,12 +146,13 @@ pub fn get_sig_op_count<T: VerifiableTransaction>(
 ) -> Result<u8, TxScriptError> {
     let sig_cache = Cache::new(0);
     let reused_values = SigHashReusedValuesUnsync::new();
-    let mut vm = TxScriptEngine::from_transaction_input(
+    let mut vm = TxScriptEngine::from_transaction_input_with_covenants(
         tx,
         &tx.inputs()[input_idx],
         input_idx,
         tx.utxo(input_idx).ok_or_else(|| TxScriptError::InvalidInputIndex(input_idx as i32, tx.inputs().len()))?,
         &reused_values,
+        &covenants_ctx,
         &sig_cache,
         Default::default(),
     );
@@ -238,46 +236,6 @@ pub fn is_unspendable<T: VerifiableTransaction, Reused: SigHashReusedValues>(scr
     parse_script::<T, Reused>(script).enumerate().any(|(index, op)| op.is_err() || (index == 0 && op.unwrap().value() == OpReturn))
 }
 
-/// Context for an input's specific authority over a subset of outputs.
-///
-/// Used by scripts to verify the state transitions they directly authorized
-/// (e.g., 1-to-N splits) without scanning unrelated outputs.
-pub struct CovenantLocalContext {
-    /// The covenant ID shared by this input and its authorized outputs.
-    pub covenant_id: Hash,
-
-    /// Indices of outputs that explicitly declare this input as their `authorizing_input`.
-    ///
-    /// This defines the input's direct "children" in the transaction.
-    pub authorized_outputs: Vec<usize>,
-}
-
-/// Context for the transaction-wide state of a specific Covenant ID.
-///
-/// Used for verifying global invariants across all participants of the same covenant
-/// (e.g., merges, batching, or conservation of amounts).
-pub struct CovenantGlobalContext {
-    /// Indices of *all* inputs in the transaction carrying this `covenant_id`.
-    pub input_indices: Vec<usize>,
-
-    /// Indices of *all* outputs in the transaction carrying this `covenant_id`.
-    pub output_indices: Vec<usize>,
-}
-
-/// Pre-computed cache mapping inputs and covenant IDs to their execution contexts.
-///
-/// Enables O(1) access for covenant introspection opcodes.
-#[derive(Default)]
-pub struct CovenantsContext {
-    /// Maps an input index to its local authority context.
-    pub local_ctxs: HashMap<usize, CovenantLocalContext>,
-
-    /// Maps a covenant id to its global context.
-    pub covenant_ctxs: HashMap<Hash, CovenantGlobalContext>,
-}
-
-static EMPTY_CONTEXT: LazyLock<CovenantsContext> = LazyLock::new(|| CovenantsContext::default());
-
 impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'a, T, Reused> {
     pub fn new(reused_values: &'a Reused, sig_cache: &'a Cache<SigCacheKey, bool>, flags: EngineFlags) -> Self {
         Self {
@@ -285,7 +243,7 @@ impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'
             astack: Self::new_stack(flags),
             script_source: ScriptSource::StandAloneScripts(vec![]),
             reused_values,
-            covenants_ctx: &EMPTY_CONTEXT,
+            covenants_ctx: &EMPTY_COV_CONTEXT,
             sig_cache,
             cond_stack: vec![],
             num_ops: 0,
@@ -367,7 +325,7 @@ impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'
             astack: Self::new_stack(flags),
             script_source: ScriptSource::TxInput { tx, input, idx: input_idx, utxo_entry, is_p2sh },
             reused_values,
-            covenants_ctx: &EMPTY_CONTEXT,
+            covenants_ctx: &EMPTY_COV_CONTEXT,
             sig_cache,
             cond_stack: Default::default(),
             num_ops: 0,
@@ -375,47 +333,6 @@ impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'
             flags,
         }
     }
-
-    pub(crate) fn cov_out_idx(&self, input_idx: usize, authorized_idx: usize) -> Result<usize, TxScriptError> {
-        // let map = self.cov_out_indices.as_ref().expect("shouldn't be called for standalone scripts");
-        // let index_vec = map.get(input_idx).ok_or(TxScriptError::InvalidInputIndex(input_idx as i32, map.len()))?;
-        // index_vec.get(authorized_idx).copied().ok_or(TxScriptError::InvalidCovOutIndex(authorized_idx, input_idx, index_vec.len()))
-
-        let output_indices = &self
-            .covenants_ctx
-            .local_ctxs
-            .get(&input_idx)
-            .ok_or(TxScriptError::InvalidCovInputIndex(input_idx as i32))?
-            .authorized_outputs;
-        output_indices.get(authorized_idx).copied().ok_or(TxScriptError::InvalidCovOutIndex(
-            authorized_idx,
-            input_idx,
-            output_indices.len(),
-        ))
-    }
-
-    pub(crate) fn cov_out_count(&self, input_idx: usize) -> Result<usize, TxScriptError> {
-        // let map = self.cov_out_indices.as_ref().expect("shouldn't be called for standalone scripts");
-        // map.get(input_idx).ok_or(TxScriptError::InvalidInputIndex(input_idx as i32, map.len())).map(|v| v.len())
-
-        Ok(self
-            .covenants_ctx
-            .local_ctxs
-            .get(&input_idx)
-            .ok_or(TxScriptError::InvalidCovInputIndex(input_idx as i32))?
-            .authorized_outputs
-            .len())
-    }
-
-    // fn calc_cov_out_indices(tx: &'a T) -> Vec<Vec<usize>> {
-    //     let mut map = vec![Vec::with_capacity(tx.outputs().len()); tx.tx().inputs.len()];
-    //     for (out_idx, output) in tx.tx().outputs.iter().enumerate() {
-    //         if let Some(cov_out_info) = output.cov_out_info {
-    //             map[cov_out_info.authorizing_input as usize].push(out_idx);
-    //         }
-    //     }
-    //     map
-    // }
 
     pub fn from_script(
         script: &'a [u8],
@@ -428,7 +345,7 @@ impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'
             astack: Self::new_stack(flags),
             script_source: ScriptSource::StandAloneScripts(vec![script]),
             reused_values,
-            covenants_ctx: &EMPTY_CONTEXT,
+            covenants_ctx: &EMPTY_COV_CONTEXT,
             sig_cache,
             cond_stack: Default::default(),
             num_ops: 0,

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -14,6 +14,9 @@ pub mod wasm;
 
 pub mod runtime_sig_op_counter;
 
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
 use crate::caches::Cache;
 use crate::data_stack::Stack;
 use crate::opcodes::{deserialize_next_opcode, OpCodeImplementation};
@@ -23,6 +26,7 @@ use kaspa_consensus_core::hashing::sighash::{
 };
 use kaspa_consensus_core::hashing::sighash_type::SigHashType;
 use kaspa_consensus_core::tx::{ScriptPublicKey, TransactionInput, UtxoEntry, VerifiableTransaction};
+use kaspa_hashes::Hash;
 use kaspa_txscript_errors::TxScriptError;
 use log::trace;
 use once_cell::unsync::Lazy;
@@ -91,6 +95,7 @@ pub struct TxScriptEngine<'a, T: VerifiableTransaction, Reused: SigHashReusedVal
 
     // Outer caches for quicker calculation
     reused_values: &'a Reused,
+    covenants_ctx: &'a CovenantsContext,
     sig_cache: &'a Cache<SigCacheKey, bool>,
 
     cond_stack: Vec<OpCond>, // Following if stacks, and whether it is running
@@ -98,7 +103,6 @@ pub struct TxScriptEngine<'a, T: VerifiableTransaction, Reused: SigHashReusedVal
     num_ops: i32,
     runtime_sig_op_counter: RuntimeSigOpCounter,
     flags: EngineFlags,
-    cov_out_indices: Option<Lazy<Vec<Vec<usize>>, Box<dyn FnOnce() -> Vec<Vec<usize>> + 'a>>>,
 }
 
 fn parse_script<T: VerifiableTransaction, Reused: SigHashReusedValues>(
@@ -138,7 +142,11 @@ fn parse_script<T: VerifiableTransaction, Reused: SigHashReusedValues>(
 /// # Returns
 /// * `Ok(u8)` - The exact number of signature operations executed
 /// * `Err(TxScriptError)` - If script execution fails or input index is invalid
-pub fn get_sig_op_count<T: VerifiableTransaction>(tx: &T, input_idx: usize) -> Result<u8, TxScriptError> {
+pub fn get_sig_op_count<T: VerifiableTransaction>(
+    tx: &T,
+    covenants_ctx: &CovenantsContext,
+    input_idx: usize,
+) -> Result<u8, TxScriptError> {
     let sig_cache = Cache::new(0);
     let reused_values = SigHashReusedValuesUnsync::new();
     let mut vm = TxScriptEngine::from_transaction_input(
@@ -230,6 +238,18 @@ pub fn is_unspendable<T: VerifiableTransaction, Reused: SigHashReusedValues>(scr
     parse_script::<T, Reused>(script).enumerate().any(|(index, op)| op.is_err() || (index == 0 && op.unwrap().value() == OpReturn))
 }
 
+pub struct CovenantInputContext {
+    pub covenant_id: Hash,
+    pub output_indices: Vec<usize>,
+}
+
+#[derive(Default)]
+pub struct CovenantsContext {
+    pub per_input_ctx: HashMap<usize, CovenantInputContext>,
+}
+
+static EMPTY_CONTEXT: LazyLock<CovenantsContext> = LazyLock::new(|| CovenantsContext::default());
+
 impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'a, T, Reused> {
     pub fn new(reused_values: &'a Reused, sig_cache: &'a Cache<SigCacheKey, bool>, flags: EngineFlags) -> Self {
         Self {
@@ -237,12 +257,12 @@ impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'
             astack: Self::new_stack(flags),
             script_source: ScriptSource::StandAloneScripts(vec![]),
             reused_values,
+            covenants_ctx: &EMPTY_CONTEXT,
             sig_cache,
             cond_stack: vec![],
             num_ops: 0,
             runtime_sig_op_counter: RuntimeSigOpCounter::new(u8::MAX),
             flags,
-            cov_out_indices: None,
         }
     }
 
@@ -271,6 +291,35 @@ impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'
     ///
     /// # Returns
     /// Script engine instance configured for the given input
+    pub fn from_transaction_input_with_covenants(
+        tx: &'a T,
+        input: &'a TransactionInput,
+        input_idx: usize,
+        utxo_entry: &'a UtxoEntry,
+        reused_values: &'a Reused,
+        covenants_ctx: &'a CovenantsContext,
+        sig_cache: &'a Cache<SigCacheKey, bool>,
+        flags: EngineFlags,
+    ) -> Self {
+        let script_public_key = utxo_entry.script_public_key.script();
+        // The script_public_key in P2SH is just validating the hash on the OpMultiSig script
+        // the user provides
+        let is_p2sh = ScriptClass::is_pay_to_script_hash(script_public_key);
+        assert!(input_idx < tx.tx().inputs.len());
+        Self {
+            dstack: Self::new_stack(flags),
+            astack: Self::new_stack(flags),
+            script_source: ScriptSource::TxInput { tx, input, idx: input_idx, utxo_entry, is_p2sh },
+            reused_values,
+            covenants_ctx,
+            sig_cache,
+            cond_stack: Default::default(),
+            num_ops: 0,
+            runtime_sig_op_counter: RuntimeSigOpCounter::new(input.sig_op_count),
+            flags,
+        }
+    }
+
     pub fn from_transaction_input(
         tx: &'a T,
         input: &'a TransactionInput,
@@ -290,35 +339,55 @@ impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'
             astack: Self::new_stack(flags),
             script_source: ScriptSource::TxInput { tx, input, idx: input_idx, utxo_entry, is_p2sh },
             reused_values,
+            covenants_ctx: &EMPTY_CONTEXT,
             sig_cache,
             cond_stack: Default::default(),
             num_ops: 0,
             runtime_sig_op_counter: RuntimeSigOpCounter::new(input.sig_op_count),
             flags,
-            cov_out_indices: Some(Lazy::new(Box::new(move || Self::calc_cov_out_indices(tx)))),
         }
     }
 
     pub(crate) fn cov_out_idx(&self, input_idx: usize, authorized_idx: usize) -> Result<usize, TxScriptError> {
-        let map = self.cov_out_indices.as_ref().expect("shouldn't be called for standalone scripts");
-        let index_vec = map.get(input_idx).ok_or(TxScriptError::InvalidInputIndex(input_idx as i32, map.len()))?;
-        index_vec.get(authorized_idx).copied().ok_or(TxScriptError::InvalidCovOutIndex(authorized_idx, input_idx, index_vec.len()))
+        // let map = self.cov_out_indices.as_ref().expect("shouldn't be called for standalone scripts");
+        // let index_vec = map.get(input_idx).ok_or(TxScriptError::InvalidInputIndex(input_idx as i32, map.len()))?;
+        // index_vec.get(authorized_idx).copied().ok_or(TxScriptError::InvalidCovOutIndex(authorized_idx, input_idx, index_vec.len()))
+
+        let output_indices = &self
+            .covenants_ctx
+            .per_input_ctx
+            .get(&input_idx)
+            .ok_or(TxScriptError::InvalidCovInputIndex(input_idx as i32))?
+            .output_indices;
+        output_indices.get(authorized_idx).copied().ok_or(TxScriptError::InvalidCovOutIndex(
+            authorized_idx,
+            input_idx,
+            output_indices.len(),
+        ))
     }
 
     pub(crate) fn cov_out_count(&self, input_idx: usize) -> Result<usize, TxScriptError> {
-        let map = self.cov_out_indices.as_ref().expect("shouldn't be called for standalone scripts");
-        map.get(input_idx).ok_or(TxScriptError::InvalidInputIndex(input_idx as i32, map.len())).map(|v| v.len())
+        // let map = self.cov_out_indices.as_ref().expect("shouldn't be called for standalone scripts");
+        // map.get(input_idx).ok_or(TxScriptError::InvalidInputIndex(input_idx as i32, map.len())).map(|v| v.len())
+
+        Ok(self
+            .covenants_ctx
+            .per_input_ctx
+            .get(&input_idx)
+            .ok_or(TxScriptError::InvalidCovInputIndex(input_idx as i32))?
+            .output_indices
+            .len())
     }
 
-    fn calc_cov_out_indices(tx: &'a T) -> Vec<Vec<usize>> {
-        let mut map = vec![Vec::with_capacity(tx.outputs().len()); tx.tx().inputs.len()];
-        for (out_idx, output) in tx.tx().outputs.iter().enumerate() {
-            if let Some(cov_out_info) = output.cov_out_info {
-                map[cov_out_info.authorizing_input as usize].push(out_idx);
-            }
-        }
-        map
-    }
+    // fn calc_cov_out_indices(tx: &'a T) -> Vec<Vec<usize>> {
+    //     let mut map = vec![Vec::with_capacity(tx.outputs().len()); tx.tx().inputs.len()];
+    //     for (out_idx, output) in tx.tx().outputs.iter().enumerate() {
+    //         if let Some(cov_out_info) = output.cov_out_info {
+    //             map[cov_out_info.authorizing_input as usize].push(out_idx);
+    //         }
+    //     }
+    //     map
+    // }
 
     pub fn from_script(
         script: &'a [u8],
@@ -331,13 +400,13 @@ impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'
             astack: Self::new_stack(flags),
             script_source: ScriptSource::StandAloneScripts(vec![script]),
             reused_values,
+            covenants_ctx: &EMPTY_CONTEXT,
             sig_cache,
             cond_stack: Default::default(),
             num_ops: 0,
             // Runtime sig op counting is not needed for standalone scripts, only inputs have sig op count value
             runtime_sig_op_counter: RuntimeSigOpCounter::new(u8::MAX),
             flags,
-            cov_out_indices: None,
         }
     }
 

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -246,6 +246,7 @@ pub struct CovenantInputContext {
 #[derive(Default)]
 pub struct CovenantsContext {
     pub per_input_ctx: HashMap<usize, CovenantInputContext>,
+    // TODO: per covenant map to both ins and outs
 }
 
 static EMPTY_CONTEXT: LazyLock<CovenantsContext> = LazyLock::new(|| CovenantsContext::default());

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -86,23 +86,46 @@ pub struct EngineFlags {
     pub covenants_enabled: bool,
 }
 
-pub struct EngineContext<'a, Reused: SigHashReusedValues> {
+/// Marker type indicating that sig-hash reused values have not been bound yet.
+#[derive(Default)]
+pub struct MissingReusedValues;
+
+/// Shared execution context for script evaluation.
+///
+/// Parameterized by the availability/type of sig-hash reused values.
+pub struct EngineContext<'a, Reused> {
     reused_values: &'a Reused,
     sig_cache: &'a Cache<SigCacheKey, bool>,
     covenants_ctx: &'a CovenantsContext,
 }
 
+impl<'a, Reused> EngineContext<'a, Reused> {
+    /// Attach a covenants context to an existing engine context.
+    pub fn with_covenants_ctx(mut self, covenants_ctx: &'a CovenantsContext) -> Self {
+        self.covenants_ctx = covenants_ctx;
+        self
+    }
+}
+
 impl<'a, Reused: SigHashReusedValues> EngineContext<'a, Reused> {
+    /// Create a context with bound reused values, using an empty covenants context.
     pub fn new(reused_values: &'a Reused, sig_cache: &'a Cache<SigCacheKey, bool>) -> Self {
         Self { reused_values, sig_cache, covenants_ctx: &EMPTY_COV_CONTEXT }
     }
+}
 
-    pub fn with_covenants_ctx(
-        reused_values: &'a Reused,
-        sig_cache: &'a Cache<SigCacheKey, bool>,
-        covenants_ctx: &'a CovenantsContext,
-    ) -> Self {
-        Self { reused_values, sig_cache, covenants_ctx }
+impl<'a> EngineContext<'a, MissingReusedValues> {
+    const MISSING: MissingReusedValues = MissingReusedValues;
+
+    /// Create a context without bound reused values, using an empty covenants context.
+    pub fn with_missing(sig_cache: &'a Cache<SigCacheKey, bool>) -> Self {
+        Self { reused_values: &Self::MISSING, sig_cache, covenants_ctx: &EMPTY_COV_CONTEXT }
+    }
+
+    /// Upgrade the context by binding concrete sig-hash reused values (one-way).
+    #[inline]
+    pub fn with_reused<New: SigHashReusedValues>(self, reused_values: &'a New) -> EngineContext<'a, New> {
+        EngineContext { reused_values, sig_cache: self.sig_cache, covenants_ctx: self.covenants_ctx }
     }
 }
 
@@ -181,7 +204,7 @@ pub fn get_sig_op_count<T: VerifiableTransaction>(
 ) -> Result<u8, TxScriptError> {
     let sig_cache = Cache::new(0);
     let reused_values = SigHashReusedValuesUnsync::new();
-    let ctx = EngineContext::with_covenants_ctx(&reused_values, &sig_cache, covenants_ctx);
+    let ctx = EngineContext::new(&reused_values, &sig_cache).with_covenants_ctx(covenants_ctx);
     let mut vm = TxScriptEngine::from_transaction_input(
         tx,
         &tx.inputs()[input_idx],

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -18,7 +18,7 @@ pub mod runtime_sig_op_counter;
 use std::ops::Deref;
 
 use crate::caches::Cache;
-use crate::covenants::{CovenantsContext, EMPTY_COV_CONTEXT};
+use crate::covenants::CovenantsContext;
 use crate::data_stack::Stack;
 use crate::opcodes::{deserialize_next_opcode, OpCodeImplementation};
 use itertools::Itertools;
@@ -37,7 +37,14 @@ pub mod prelude {
     pub use super::standard::*;
 }
 use crate::runtime_sig_op_counter::RuntimeSigOpCounter;
+pub use crate::seq_commit_accessor::SeqCommitAccessor;
 pub use standard::*;
+
+pub mod seq_commit_accessor;
+
+pub mod engine_context;
+
+pub use engine_context::{EngineContext, MissingReusedValues};
 
 pub const MAX_SCRIPT_PUBLIC_KEY_VERSION: u16 = 0;
 pub const MAX_STACK_SIZE: usize = 244;
@@ -85,57 +92,6 @@ enum ScriptSource<'a, T: VerifiableTransaction> {
 pub struct EngineFlags {
     pub covenants_enabled: bool,
 }
-
-/// Marker type indicating that sig-hash reused values have not been bound yet.
-#[derive(Default)]
-pub struct MissingReusedValues;
-
-/// Shared execution context for script evaluation.
-///
-/// Parameterized by the availability/type of sig-hash reused values.
-pub struct EngineContext<'a, Reused> {
-    reused_values: &'a Reused,
-    sig_cache: &'a Cache<SigCacheKey, bool>,
-    covenants_ctx: &'a CovenantsContext,
-}
-
-impl<'a, Reused> EngineContext<'a, Reused> {
-    /// Attach a covenants context to an existing engine context.
-    pub fn with_covenants_ctx(mut self, covenants_ctx: &'a CovenantsContext) -> Self {
-        self.covenants_ctx = covenants_ctx;
-        self
-    }
-}
-
-impl<'a, Reused: SigHashReusedValues> EngineContext<'a, Reused> {
-    /// Create a context with bound reused values, using an empty covenants context.
-    pub fn new(reused_values: &'a Reused, sig_cache: &'a Cache<SigCacheKey, bool>) -> Self {
-        Self { reused_values, sig_cache, covenants_ctx: &EMPTY_COV_CONTEXT }
-    }
-}
-
-impl<'a> EngineContext<'a, MissingReusedValues> {
-    const MISSING: MissingReusedValues = MissingReusedValues;
-
-    /// Create a context without bound reused values, using an empty covenants context.
-    pub fn with_missing(sig_cache: &'a Cache<SigCacheKey, bool>) -> Self {
-        Self { reused_values: &Self::MISSING, sig_cache, covenants_ctx: &EMPTY_COV_CONTEXT }
-    }
-
-    /// Upgrade the context by binding concrete sig-hash reused values (one-way).
-    #[inline]
-    pub fn with_reused<New: SigHashReusedValues>(self, reused_values: &'a New) -> EngineContext<'a, New> {
-        EngineContext { reused_values, sig_cache: self.sig_cache, covenants_ctx: self.covenants_ctx }
-    }
-}
-
-impl<'a, Reused: SigHashReusedValues> Clone for EngineContext<'a, Reused> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<'a, Reused: SigHashReusedValues> Copy for EngineContext<'a, Reused> {}
 
 impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> Deref for TxScriptEngine<'a, T, Reused> {
     type Target = EngineContext<'a, Reused>;
@@ -201,10 +157,11 @@ pub fn get_sig_op_count<T: VerifiableTransaction>(
     tx: &T,
     input_idx: usize,
     covenants_ctx: &CovenantsContext,
+    dag: Option<&dyn SeqCommitAccessor>,
 ) -> Result<u8, TxScriptError> {
     let sig_cache = Cache::new(0);
     let reused_values = SigHashReusedValuesUnsync::new();
-    let ctx = EngineContext::new(&reused_values, &sig_cache).with_covenants_ctx(covenants_ctx);
+    let ctx = EngineContext::new(&reused_values, &sig_cache).with_covenants_ctx(covenants_ctx).with_seq_commit_accessor_opt(dag);
     let mut vm = TxScriptEngine::from_transaction_input(
         tx,
         &tx.inputs()[input_idx],
@@ -471,8 +428,7 @@ impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'
         // try_for_each quits only if an error occurred. So, we always run over all scripts if
         // each is successful
         scripts.iter().enumerate().filter(|(_, s)| !s.is_empty()).try_for_each(|(idx, s)| {
-            let verify_only_push =
-                idx == 0 && matches!(self.script_source, ScriptSource::TxInput { tx: _, input: _, idx: _, utxo_entry: _, is_p2sh: _ });
+            let verify_only_push = idx == 0 && matches!(self.script_source, ScriptSource::TxInput { .. });
             // Save script in p2sh
             if is_p2sh && idx == 1 {
                 saved_stack = Some(self.dstack.clone());
@@ -1386,6 +1342,7 @@ mod bitcoind_tests {
     use kaspa_consensus_core::tx::{
         PopulatedTransaction, ScriptPublicKey, Transaction, TransactionId, TransactionOutpoint, TransactionOutput,
     };
+    use kaspa_hashes::Hash;
 
     #[derive(PartialEq, Eq, Debug, Clone)]
     enum UnifiedError {
@@ -1480,12 +1437,46 @@ mod bitcoind_tests {
             // Run transaction
             let sig_cache = Cache::new(10_000);
             let reused_values = SigHashReusedValuesUnsync::new();
+
+            struct MockSeqCommitAccessor;
+            const EXPECTED_INPUT_BLOCK_HASH: [u8; 32] = {
+                let mut block = [b'f'; 32];
+                let input = b"input_block";
+                let mut i = 0;
+                while i < input.len() {
+                    block[i] = input[i];
+                    i += 1;
+                }
+                block
+            };
+
+            const EXPECTED_OUTPUT_ROOT_HASH: [u8; 32] = {
+                let mut block = [b'f'; 32];
+                let input = b"output_root_hash";
+                let mut i = 0;
+                while i < input.len() {
+                    block[i] = input[i];
+                    i += 1;
+                }
+                block
+            };
+            impl SeqCommitAccessor for MockSeqCommitAccessor {
+                fn is_chain_ancestor_from_pov(&self, block_hash: Hash) -> Option<bool> {
+                    (block_hash == Hash::from(EXPECTED_INPUT_BLOCK_HASH)).then_some(true)
+                }
+
+                fn seq_commitment_within_depth(&self, block_hash: Hash) -> Option<Hash> {
+                    (block_hash == Hash::from(EXPECTED_INPUT_BLOCK_HASH)).then_some(Hash::from(EXPECTED_OUTPUT_ROOT_HASH))
+                }
+            }
+
             let mut vm = TxScriptEngine::from_transaction_input(
                 &populated_tx,
                 &populated_tx.tx().inputs[0],
                 0,
                 &populated_tx.entries[0],
-                EngineContext::new(&reused_values, &sig_cache),
+                EngineContext::new(&reused_values, &sig_cache)
+                    .with_seq_commit_accessor_opt(flags.covenants_enabled.then_some(&MockSeqCommitAccessor)),
                 flags,
             );
             vm.execute().map_err(UnifiedError::TxScriptError)

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -722,7 +722,7 @@ mod tests {
             let output = TransactionOutput {
                 value: 1000000000,
                 script_public_key: ScriptPublicKey::new(0, test.script.into()),
-                cov_out_info: None,
+                covenant: None,
             };
 
             let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);

--- a/crypto/txscript/src/lib.rs
+++ b/crypto/txscript/src/lib.rs
@@ -44,7 +44,8 @@ pub mod seq_commit_accessor;
 
 pub mod engine_context;
 
-pub use engine_context::{EngineContext, MissingReusedValues};
+pub(crate) use engine_context::EngineContext;
+pub use engine_context::{EngineCtx, EngineCtxSync, EngineCtxUnsync};
 
 pub const MAX_SCRIPT_PUBLIC_KEY_VERSION: u16 = 0;
 pub const MAX_STACK_SIZE: usize = 244;
@@ -157,11 +158,14 @@ pub fn get_sig_op_count<T: VerifiableTransaction>(
     tx: &T,
     input_idx: usize,
     covenants_ctx: &CovenantsContext,
-    dag: Option<&dyn SeqCommitAccessor>,
+    seq_commit_accessor: Option<&dyn SeqCommitAccessor>,
 ) -> Result<u8, TxScriptError> {
     let sig_cache = Cache::new(0);
     let reused_values = SigHashReusedValuesUnsync::new();
-    let ctx = EngineContext::new(&reused_values, &sig_cache).with_covenants_ctx(covenants_ctx).with_seq_commit_accessor_opt(dag);
+    let ctx = EngineCtx::new(&sig_cache)
+        .with_reused(&reused_values)
+        .with_covenants_ctx(covenants_ctx)
+        .with_seq_commit_accessor_opt(seq_commit_accessor);
     let mut vm = TxScriptEngine::from_transaction_input(
         tx,
         &tx.inputs()[input_idx],
@@ -324,7 +328,7 @@ impl<'a, T: VerifiableTransaction, Reused: SigHashReusedValues> TxScriptEngine<'
             dstack: Self::new_stack(flags),
             astack: Self::new_stack(flags),
             script_source: ScriptSource::StandAloneScripts(vec![script]),
-            ctx: EngineContext::new(reused_values, sig_cache),
+            ctx: EngineCtx::new(sig_cache).with_reused(reused_values),
             cond_stack: Default::default(),
             num_ops: 0,
             // Runtime sig op counting is not needed for standalone scripts, only inputs have sig op count value
@@ -731,7 +735,7 @@ mod tests {
                 &input,
                 0,
                 &utxo_entry,
-                EngineContext::new(&reused_values, &sig_cache),
+                EngineCtx::new(&sig_cache).with_reused(&reused_values),
                 Default::default(),
             );
             assert_eq!(vm.execute(), test.expected_result);
@@ -1297,7 +1301,7 @@ mod tests {
                 &tx.inputs()[0],
                 0,
                 &utxo_entry,
-                EngineContext::new(&reused_values, &sig_cache),
+                EngineCtx::new(&sig_cache).with_reused(&reused_values),
                 Default::default(),
             );
 
@@ -1475,7 +1479,8 @@ mod bitcoind_tests {
                 &populated_tx.tx().inputs[0],
                 0,
                 &populated_tx.entries[0],
-                EngineContext::new(&reused_values, &sig_cache)
+                EngineCtx::new(&sig_cache)
+                    .with_reused(&reused_values)
                     .with_seq_commit_accessor_opt(flags.covenants_enabled.then_some(&MockSeqCommitAccessor)),
                 flags,
             );

--- a/crypto/txscript/src/opcodes/mod.rs
+++ b/crypto/txscript/src/opcodes/mod.rs
@@ -1355,13 +1355,9 @@ opcode_list! {
         if vm.flags.covenants_enabled {
             match vm.script_source {
                 ScriptSource::TxInput{tx, ..} => {
-                    // // TODO: Add optimization
-                    // let count = tx.outputs().iter()
-                    //     .filter(|output| output.cov_out_info.is_some_and(|x| x.authorizing_input as usize == idx))
-                    //     .count();
                     let [input_idx]: [i32; 1] = vm.dstack.pop_items()?;
                     let input_idx = i32_to_usize(input_idx)?;
-                    let count = vm.cov_out_count(input_idx)?;
+                    let count = vm.covenants_ctx.num_auth_outputs(input_idx)?;
                     push_number(count as i64, vm)
                 },
                 _ => Err(TxScriptError::InvalidSource("OpCovOutCount only applies to transaction inputs".to_string()))
@@ -1375,18 +1371,9 @@ opcode_list! {
         if vm.flags.covenants_enabled {
             match vm.script_source {
                 ScriptSource::TxInput{tx, ..} => {
-                    let [input_idx, authorized_idx]: [i32; 2] = vm.dstack.pop_items()?;
-                    let input_idx = i32_to_usize(input_idx)?;
-                    let authorized_idx = i32_to_usize(authorized_idx)?;
-
-                    // // TODO: Add optimization
-                    // let output_idx = tx.outputs().iter().enumerate()
-                    //     .filter(|(i,output)| output.cov_out_info.is_some_and(|x| x.authorizing_input as usize == idx))
-                    //     .map(|(i, _)| i)
-                    //     .nth(cov_out_idx)
-                    //     .ok_or(TxScriptError::InvalidIndex(cov_out_idx as i32))?;
-
-                    let output_idx = vm.cov_out_idx(input_idx, authorized_idx)?;
+                    let [input_idx, k]: [i32; 2] = vm.dstack.pop_items()?;
+                    let (input_idx, k) = (i32_to_usize(input_idx)?, i32_to_usize(k)?);
+                    let output_idx = vm.covenants_ctx.auth_output_index(input_idx, k)?;
                     push_number(output_idx as i64, vm)
                 },
                 _ => Err(TxScriptError::InvalidSource("OpCovOutIdx only applies to transaction inputs".to_string()))

--- a/crypto/txscript/src/opcodes/mod.rs
+++ b/crypto/txscript/src/opcodes/mod.rs
@@ -1478,7 +1478,7 @@ mod test {
     use crate::caches::Cache;
     use crate::data_stack::Stack;
     use crate::opcodes::{OpCodeExecution, OpCodeImplementation};
-    use crate::{opcodes, pay_to_address_script, TxScriptEngine, TxScriptError, LOCK_TIME_THRESHOLD};
+    use crate::{opcodes, pay_to_address_script, EngineContext, TxScriptEngine, TxScriptError, LOCK_TIME_THRESHOLD};
     use kaspa_addresses::{Address, Prefix, Version};
     use kaspa_consensus_core::constants::{SOMPI_PER_KASPA, TX_VERSION};
     use kaspa_consensus_core::hashing::sighash::SigHashReusedValuesUnsync;
@@ -1503,10 +1503,11 @@ mod test {
     fn run_success_test_cases(tests: Vec<TestCase>) {
         let cache = Cache::new(10_000);
         let reused_values = SigHashReusedValuesUnsync::new();
+        let ctx = EngineContext::new(&reused_values, &cache);
         for TestCase { init, code, dstack } in tests {
             let init: Stack = init.into();
             let dstack = dstack.into();
-            let mut vm = TxScriptEngine::new(&reused_values, &cache, Default::default());
+            let mut vm = TxScriptEngine::new(ctx, Default::default());
             vm.dstack = init.clone();
             code.execute(&mut vm).unwrap_or_else(|_| panic!("Opcode {} should not fail", code.value()));
             assert_eq!(vm.dstack, dstack, "OpCode {} Pushed wrong value", code.value());
@@ -1516,8 +1517,9 @@ mod test {
     fn run_error_test_cases(tests: Vec<ErrorTestCase>) {
         let cache = Cache::new(10_000);
         let reused_values = SigHashReusedValuesUnsync::new();
+        let ctx = EngineContext::new(&reused_values, &cache);
         for ErrorTestCase { init, code, error } in tests {
-            let mut vm = TxScriptEngine::new(&reused_values, &cache, Default::default());
+            let mut vm = TxScriptEngine::new(ctx, Default::default());
             vm.dstack = init.clone().into();
             assert_eq!(
                 code.execute(&mut vm)
@@ -1552,7 +1554,8 @@ mod test {
 
         let cache = Cache::new(10_000);
         let reused_values = SigHashReusedValuesUnsync::new();
-        let mut vm = TxScriptEngine::new(&reused_values, &cache, Default::default());
+        let ctx = EngineContext::new(&reused_values, &cache);
+        let mut vm = TxScriptEngine::new(ctx, Default::default());
 
         for pop in tests {
             match pop.execute(&mut vm) {
@@ -1582,7 +1585,8 @@ mod test {
 
         let cache = Cache::new(10_000);
         let reused_values = SigHashReusedValuesUnsync::new();
-        let mut vm = TxScriptEngine::new(&reused_values, &cache, Default::default());
+        let ctx = EngineContext::new(&reused_values, &cache);
+        let mut vm = TxScriptEngine::new(ctx, Default::default());
 
         for pop in tests {
             match pop.execute(&mut vm) {
@@ -1656,7 +1660,8 @@ mod test {
 
         let cache = Cache::new(10_000);
         let reused_values = SigHashReusedValuesUnsync::new();
-        let mut vm = TxScriptEngine::new(&reused_values, &cache, Default::default());
+        let ctx = EngineContext::new(&reused_values, &cache);
+        let mut vm = TxScriptEngine::new(ctx, Default::default());
 
         for pop in tests {
             match pop.execute(&mut vm) {
@@ -3240,6 +3245,7 @@ mod test {
 
         let sig_cache = Cache::new(10_000);
         let reused_values = SigHashReusedValuesUnsync::new();
+        let ctx = EngineContext::new(&reused_values, &sig_cache);
 
         let code = opcodes::OpCheckLockTimeVerify::empty().expect("Should accept empty");
 
@@ -3251,8 +3257,7 @@ mod test {
         ] {
             let mut tx = base_tx.clone();
             tx.0.lock_time = tx_lock_time;
-            let mut vm =
-                TxScriptEngine::from_transaction_input(&tx, &input, 0, &utxo_entry, &reused_values, &sig_cache, Default::default());
+            let mut vm = TxScriptEngine::from_transaction_input(&tx, &input, 0, &utxo_entry, ctx, Default::default());
             vm.dstack = vec![lock_time.clone()].into();
             match code.execute(&mut vm) {
                 // Message is based on the should_fail values
@@ -3282,6 +3287,7 @@ mod test {
 
         let sig_cache = Cache::new(10_000);
         let reused_values = SigHashReusedValuesUnsync::new();
+        let ctx = EngineContext::new(&reused_values, &sig_cache);
 
         let code = opcodes::OpCheckSequenceVerify::empty().expect("Should accept empty");
 
@@ -3294,8 +3300,7 @@ mod test {
         ] {
             let mut input = base_input.clone();
             input.sequence = tx_sequence;
-            let mut vm =
-                TxScriptEngine::from_transaction_input(&tx, &input, 0, &utxo_entry, &reused_values, &sig_cache, Default::default());
+            let mut vm = TxScriptEngine::from_transaction_input(&tx, &input, 0, &utxo_entry, ctx, Default::default());
             vm.dstack = vec![sequence.clone()].into();
             match code.execute(&mut vm) {
                 // Message is based on the should_fail values
@@ -3481,6 +3486,7 @@ mod test {
             let tx = PopulatedTransaction::new(&tx, utxo_entries);
             let sig_cache = Cache::new(10_000);
             let reused_values = SigHashReusedValuesUnsync::new();
+            let ctx = EngineContext::new(&reused_values, &sig_cache);
 
             for current_idx in 0..tx.inputs().len() {
                 let mut vm = TxScriptEngine::from_transaction_input(
@@ -3488,8 +3494,7 @@ mod test {
                     &tx.inputs()[current_idx],
                     current_idx,
                     tx.utxo(current_idx).unwrap(),
-                    &reused_values,
-                    &sig_cache,
+                    ctx,
                     Default::default(),
                 );
 
@@ -3719,14 +3724,14 @@ mod test {
                 let tx = PopulatedTransaction::new(&tx, utxo_entries);
                 let sig_cache = Cache::new(10_000);
                 let reused_values = SigHashReusedValuesUnsync::new();
+                let ctx = EngineContext::new(&reused_values, &sig_cache);
 
                 let mut vm = TxScriptEngine::from_transaction_input(
                     &tx,
                     &tx.inputs()[0], // Use first input
                     0,
                     tx.utxo(0).unwrap(),
-                    &reused_values,
-                    &sig_cache,
+                    ctx,
                     Default::default(),
                 );
 
@@ -3784,18 +3789,12 @@ mod test {
             let tx = tx.as_verifiable();
             let sig_cache = Cache::new(10_000);
             let reused_values = SigHashReusedValuesUnsync::new();
+            let ctx = EngineContext::new(&reused_values, &sig_cache);
 
             // Test success case
             {
-                let mut vm = TxScriptEngine::from_transaction_input(
-                    &tx,
-                    &tx.inputs()[0],
-                    0,
-                    tx.utxo(0).unwrap(),
-                    &reused_values,
-                    &sig_cache,
-                    Default::default(),
-                );
+                let mut vm =
+                    TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, tx.utxo(0).unwrap(), ctx, Default::default());
 
                 assert_eq!(vm.execute(), Ok(()));
             }
@@ -3811,15 +3810,8 @@ mod test {
                 tx.tx.inputs[0].signature_script = ScriptBuilder::new().add_data(&redeem_script).unwrap().drain();
 
                 let tx = tx.as_verifiable();
-                let mut vm = TxScriptEngine::from_transaction_input(
-                    &tx,
-                    &tx.inputs()[0],
-                    0,
-                    tx.utxo(0).unwrap(),
-                    &reused_values,
-                    &sig_cache,
-                    Default::default(),
-                );
+                let mut vm =
+                    TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, tx.utxo(0).unwrap(), ctx, Default::default());
 
                 assert_eq!(vm.execute(), Err(TxScriptError::EvalFalse));
             }
@@ -3840,6 +3832,7 @@ mod test {
                 .drain();
             let sig_cache = Cache::new(10_000);
             let reused_values = SigHashReusedValuesUnsync::new();
+            let ctx = EngineContext::new(&reused_values, &sig_cache);
             let spk = pay_to_script_hash_script(&redeem_script);
 
             // Test success case
@@ -3851,15 +3844,8 @@ mod test {
                 let mut tx = MutableTransaction::with_entries(tx, utxo_entries);
                 tx.tx.inputs[0].signature_script = ScriptBuilder::new().add_data(&redeem_script).unwrap().drain();
                 let tx = tx.as_verifiable();
-                let mut vm = TxScriptEngine::from_transaction_input(
-                    &tx,
-                    &tx.inputs()[0],
-                    0,
-                    tx.utxo(0).unwrap(),
-                    &reused_values,
-                    &sig_cache,
-                    Default::default(),
-                );
+                let mut vm =
+                    TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, tx.utxo(0).unwrap(), ctx, Default::default());
 
                 assert_eq!(vm.execute(), Ok(()));
             }
@@ -3877,15 +3863,8 @@ mod test {
                 tx.tx.inputs[0].signature_script = ScriptBuilder::new().add_data(&redeem_script).unwrap().drain();
 
                 let tx = tx.as_verifiable();
-                let mut vm = TxScriptEngine::from_transaction_input(
-                    &tx,
-                    &tx.inputs()[0],
-                    0,
-                    tx.utxo(0).unwrap(),
-                    &reused_values,
-                    &sig_cache,
-                    Default::default(),
-                );
+                let mut vm =
+                    TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, tx.utxo(0).unwrap(), ctx, Default::default());
 
                 assert_eq!(vm.execute(), Err(TxScriptError::EvalFalse));
             }
@@ -3895,6 +3874,7 @@ mod test {
         fn test_input_spk_basic() {
             let sig_cache = Cache::new(10_000);
             let reused_values = SigHashReusedValuesUnsync::new();
+            let ctx = EngineContext::new(&reused_values, &sig_cache);
 
             // Create script: 0 OP_INPUTSPK OpNop
             // Just verify that OpInputSpk pushes something onto stack
@@ -3906,15 +3886,7 @@ mod test {
             tx.tx.inputs[0].signature_script = ScriptBuilder::new().add_data(&redeem_script).unwrap().drain();
 
             let tx = tx.as_verifiable();
-            let mut vm = TxScriptEngine::from_transaction_input(
-                &tx,
-                &tx.inputs()[0],
-                0,
-                tx.utxo(0).unwrap(),
-                &reused_values,
-                &sig_cache,
-                Default::default(),
-            );
+            let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, tx.utxo(0).unwrap(), ctx, Default::default());
 
             // OpInputSpk should push input's SPK onto stack, making it non-empty
             assert_eq!(vm.execute(), Ok(()));
@@ -3924,6 +3896,7 @@ mod test {
         fn test_input_spk_different() {
             let sig_cache = Cache::new(10_000);
             let reused_values = SigHashReusedValuesUnsync::new();
+            let ctx = EngineContext::new(&reused_values, &sig_cache);
 
             // Create script: 0 OP_INPUTSPK 1 OP_INPUTSPK OP_EQUAL OP_NOT
             // Verifies that two different inputs have different SPKs
@@ -3937,15 +3910,7 @@ mod test {
             tx.tx.inputs[0].signature_script = ScriptBuilder::new().add_data(&redeem_script).unwrap().drain();
 
             let tx = tx.as_verifiable();
-            let mut vm = TxScriptEngine::from_transaction_input(
-                &tx,
-                &tx.inputs()[0],
-                0,
-                tx.utxo(0).unwrap(),
-                &reused_values,
-                &sig_cache,
-                Default::default(),
-            );
+            let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, tx.utxo(0).unwrap(), ctx, Default::default());
 
             // Should succeed because the SPKs are different
             assert_eq!(vm.execute(), Ok(()));
@@ -3955,6 +3920,7 @@ mod test {
         fn test_input_spk_same() {
             let sig_cache = Cache::new(10_000);
             let reused_values = SigHashReusedValuesUnsync::new();
+            let ctx = EngineContext::new(&reused_values, &sig_cache);
 
             // Create script: 0 OP_INPUTSPK 1 OP_INPUTSPK OP_EQUAL
             // Verifies that two inputs with same SPK are equal
@@ -3969,15 +3935,7 @@ mod test {
             tx.tx.inputs[0].signature_script = ScriptBuilder::new().add_data(&redeem_script).unwrap().drain();
 
             let tx = tx.as_verifiable();
-            let mut vm = TxScriptEngine::from_transaction_input(
-                &tx,
-                &tx.inputs()[0],
-                0,
-                tx.utxo(0).unwrap(),
-                &reused_values,
-                &sig_cache,
-                Default::default(),
-            );
+            let mut vm = TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, tx.utxo(0).unwrap(), ctx, Default::default());
 
             // Should succeed because both SPKs are identical
             assert_eq!(vm.execute(), Ok(()));
@@ -3990,6 +3948,7 @@ mod test {
             let expected_spk_bytes = expected_spk.to_bytes();
             let sig_cache = Cache::new(10_000);
             let reused_values = SigHashReusedValuesUnsync::new();
+            let ctx = EngineContext::new(&reused_values, &sig_cache);
             // Create script: 0 OP_OUTPUTSPK <expected_spk_bytes> EQUAL
             let redeem_script = ScriptBuilder::new()
                 .add_op(Op0)
@@ -4014,15 +3973,8 @@ mod test {
                 tx.tx.inputs[0].signature_script = ScriptBuilder::new().add_data(&redeem_script).unwrap().drain();
 
                 let tx = tx.as_verifiable();
-                let mut vm = TxScriptEngine::from_transaction_input(
-                    &tx,
-                    &tx.inputs()[0],
-                    0,
-                    tx.utxo(0).unwrap(),
-                    &reused_values,
-                    &sig_cache,
-                    Default::default(),
-                );
+                let mut vm =
+                    TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, tx.utxo(0).unwrap(), ctx, Default::default());
 
                 assert_eq!(vm.execute(), Ok(()));
             }
@@ -4040,15 +3992,8 @@ mod test {
                 tx.tx.inputs[0].signature_script = ScriptBuilder::new().add_data(&redeem_script).unwrap().drain();
 
                 let tx = tx.as_verifiable();
-                let mut vm = TxScriptEngine::from_transaction_input(
-                    &tx,
-                    &tx.inputs()[0],
-                    0,
-                    tx.utxo(0).unwrap(),
-                    &reused_values,
-                    &sig_cache,
-                    Default::default(),
-                );
+                let mut vm =
+                    TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, tx.utxo(0).unwrap(), ctx, Default::default());
 
                 assert_eq!(vm.execute(), Err(TxScriptError::EvalFalse));
             }
@@ -4063,6 +4008,7 @@ mod test {
             let spk = pay_to_script_hash_script(&redeem_script);
             let sig_cache = Cache::new(10_000);
             let reused_values = SigHashReusedValuesUnsync::new();
+            let ctx = EngineContext::new(&reused_values, &sig_cache);
             // Test first input (success case)
             {
                 let input_mock = Kip10Mock { spk: spk.clone(), amount: 200 };
@@ -4073,15 +4019,8 @@ mod test {
                 tx.tx.inputs[0].signature_script = ScriptBuilder::new().add_data(&redeem_script).unwrap().drain();
 
                 let tx = tx.as_verifiable();
-                let mut vm = TxScriptEngine::from_transaction_input(
-                    &tx,
-                    &tx.inputs()[0],
-                    0,
-                    tx.utxo(0).unwrap(),
-                    &reused_values,
-                    &sig_cache,
-                    Default::default(),
-                );
+                let mut vm =
+                    TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, tx.utxo(0).unwrap(), ctx, Default::default());
 
                 assert_eq!(vm.execute(), Ok(()));
             }
@@ -4097,15 +4036,8 @@ mod test {
                 tx.tx.inputs[1].signature_script = ScriptBuilder::new().add_data(&redeem_script).unwrap().drain();
 
                 let tx = tx.as_verifiable();
-                let mut vm = TxScriptEngine::from_transaction_input(
-                    &tx,
-                    &tx.inputs()[1],
-                    1,
-                    tx.utxo(1).unwrap(),
-                    &reused_values,
-                    &sig_cache,
-                    Default::default(),
-                );
+                let mut vm =
+                    TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[1], 1, tx.utxo(1).unwrap(), ctx, Default::default());
 
                 // Should fail because script expects index 0 but we're at index 1
                 assert_eq!(vm.execute(), Err(TxScriptError::EvalFalse));
@@ -4116,6 +4048,7 @@ mod test {
         fn test_counts() {
             let sig_cache = Cache::new(10_000);
             let reused_values = SigHashReusedValuesUnsync::new();
+            let ctx = EngineContext::new(&reused_values, &sig_cache);
             // Test OpInputCount: "OP_INPUTCOUNT 2 EQUAL"
             let input_count_script =
                 ScriptBuilder::new().add_op(OpTxInputCount).unwrap().add_i64(2).unwrap().add_op(OpEqual).unwrap().drain();
@@ -4143,15 +4076,8 @@ mod test {
                 tx.tx.inputs[0].signature_script = ScriptBuilder::new().add_data(&input_count_script).unwrap().drain();
 
                 let tx = tx.as_verifiable();
-                let mut vm = TxScriptEngine::from_transaction_input(
-                    &tx,
-                    &tx.inputs()[0],
-                    0,
-                    tx.utxo(0).unwrap(),
-                    &reused_values,
-                    &sig_cache,
-                    Default::default(),
-                );
+                let mut vm =
+                    TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, tx.utxo(0).unwrap(), ctx, Default::default());
 
                 assert_eq!(vm.execute(), Ok(()));
             }
@@ -4162,15 +4088,8 @@ mod test {
                 tx.tx.inputs[1].signature_script = ScriptBuilder::new().add_data(&output_count_script).unwrap().drain();
 
                 let tx = tx.as_verifiable();
-                let mut vm = TxScriptEngine::from_transaction_input(
-                    &tx,
-                    &tx.inputs()[1],
-                    1,
-                    tx.utxo(1).unwrap(),
-                    &reused_values,
-                    &sig_cache,
-                    Default::default(),
-                );
+                let mut vm =
+                    TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[1], 1, tx.utxo(1).unwrap(), ctx, Default::default());
 
                 assert_eq!(vm.execute(), Ok(()));
             }
@@ -4185,15 +4104,8 @@ mod test {
                 tx.tx.inputs[0].signature_script = ScriptBuilder::new().add_data(&wrong_input_count_script).unwrap().drain();
 
                 let tx = tx.as_verifiable();
-                let mut vm = TxScriptEngine::from_transaction_input(
-                    &tx,
-                    &tx.inputs()[0],
-                    0,
-                    tx.utxo(0).unwrap(),
-                    &reused_values,
-                    &sig_cache,
-                    Default::default(),
-                );
+                let mut vm =
+                    TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[0], 0, tx.utxo(0).unwrap(), ctx, Default::default());
 
                 assert_eq!(vm.execute(), Err(TxScriptError::EvalFalse));
             }
@@ -4207,15 +4119,8 @@ mod test {
                 tx.tx.inputs[1].signature_script = ScriptBuilder::new().add_data(&wrong_output_count_script).unwrap().drain();
 
                 let tx = tx.as_verifiable();
-                let mut vm = TxScriptEngine::from_transaction_input(
-                    &tx,
-                    &tx.inputs()[1],
-                    1,
-                    tx.utxo(1).unwrap(),
-                    &reused_values,
-                    &sig_cache,
-                    Default::default(),
-                );
+                let mut vm =
+                    TxScriptEngine::from_transaction_input(&tx, &tx.inputs()[1], 1, tx.utxo(1).unwrap(), ctx, Default::default());
 
                 assert_eq!(vm.execute(), Err(TxScriptError::EvalFalse));
             }
@@ -4337,13 +4242,13 @@ mod test {
             let populated_tx = PopulatedTransaction::new(tx, entries);
             let reused_values = SigHashReusedValuesUnsync::new();
             let sig_cache = Cache::new(10_000);
+            let ctx = EngineContext::new(&reused_values, &sig_cache);
             let mut vm = TxScriptEngine::from_transaction_input(
                 &populated_tx,
                 &populated_tx.tx.inputs[idx],
                 idx,
                 &populated_tx.entries[idx],
-                &reused_values,
-                &sig_cache,
+                ctx,
                 EngineFlags { covenants_enabled: true },
             );
             vm.execute()

--- a/crypto/txscript/src/opcodes/mod.rs
+++ b/crypto/txscript/src/opcodes/mod.rs
@@ -1358,6 +1358,9 @@ opcode_list! {
                 ScriptSource::TxInput{tx, ..} => {
                     let [input_idx]: [i32; 1] = vm.dstack.pop_items()?;
                     let input_idx = i32_to_usize(input_idx)?;
+                    if input_idx >= tx.inputs().len() {
+                        return Err(TxScriptError::InvalidInputIndex(input_idx.try_into().expect("casted above"), tx.inputs().len()));
+                    }
                     let count = vm.covenants_ctx.num_auth_outputs(input_idx)?;
                     push_number(count as i64, vm)
                 },
@@ -1374,6 +1377,9 @@ opcode_list! {
                 ScriptSource::TxInput{tx, ..} => {
                     let [input_idx, k]: [i32; 2] = vm.dstack.pop_items()?;
                     let (input_idx, k) = (i32_to_usize(input_idx)?, i32_to_usize(k)?);
+                    if input_idx >= tx.inputs().len() {
+                        return Err(TxScriptError::InvalidInputIndex(input_idx.try_into().expect("casted above"), tx.inputs().len()));
+                    }
                     let output_idx = vm.covenants_ctx.auth_output_index(input_idx, k)?;
                     push_number(output_idx as i64, vm)
                 },
@@ -4146,6 +4152,7 @@ mod test {
     #[cfg(test)]
     mod introspection {
         use super::*;
+        use crate::covenants::CovenantsContext;
         use crate::script_builder::{ScriptBuilder, ScriptBuilderResult};
         use crate::{opcodes::codes, EngineFlags, SpkEncoding};
         use kaspa_consensus_core::hashing::sighash::SigHashReusedValuesUnsync;
@@ -4225,7 +4232,7 @@ mod test {
                 TransactionOutput {
                     value: 33,
                     script_public_key: ScriptPublicKey::new(0, spk.clone().into()),
-                    covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: Hash::from_u64_word(3) }),
+                    covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: Hash::from_u64_word(1) }),
                 },
                 TransactionOutput::new(44, ScriptPublicKey::new(0, spk.into())),
             ];
@@ -4235,8 +4242,8 @@ mod test {
 
             let utxo_spk = ScriptBuilder::new().add_op(codes::OpTrue).expect("spk build").drain();
             let entries = vec![
-                UtxoEntry::new(1000, ScriptPublicKey::new(0, utxo_spk.clone().into()), 0, false, None),
-                UtxoEntry::new(1000, ScriptPublicKey::new(0, utxo_spk.into()), 0, false, None),
+                UtxoEntry::new(1000, ScriptPublicKey::new(0, utxo_spk.clone().into()), 0, false, Some(Hash::from_u64_word(1))),
+                UtxoEntry::new(1000, ScriptPublicKey::new(0, utxo_spk.into()), 0, false, Some(Hash::from_u64_word(2))),
             ];
 
             (tx, entries)
@@ -4256,9 +4263,10 @@ mod test {
         fn run_script(tx: &Transaction, mut entries: Vec<UtxoEntry>, idx: usize, script: Vec<u8>) -> Result<(), TxScriptError> {
             entries[idx].script_public_key = ScriptPublicKey::new(0, script.into());
             let populated_tx = PopulatedTransaction::new(tx, entries);
-            let reused_values = SigHashReusedValuesUnsync::new();
             let sig_cache = Cache::new(10_000);
-            let ctx = EngineContext::new(&sig_cache).with_reused(&reused_values);
+            let reused_values = SigHashReusedValuesUnsync::new();
+            let covenants_ctx = CovenantsContext::from_tx(&populated_tx)?;
+            let ctx = EngineContext::new(&sig_cache).with_reused(&reused_values).with_covenants_ctx(&covenants_ctx);
             let mut vm = TxScriptEngine::from_transaction_input(
                 &populated_tx,
                 &populated_tx.tx.inputs[idx],

--- a/crypto/txscript/src/opcodes/mod.rs
+++ b/crypto/txscript/src/opcodes/mod.rs
@@ -1248,7 +1248,7 @@ opcode_list! {
                     let [idx]: [i32; 1] = vm.dstack.pop_items()?;
                     let idx = i32_to_usize(idx)?;
                     let utxo = tx.utxo(idx).ok_or_else(|| TxScriptError::InvalidInputIndex(idx as i32, tx.inputs().len()))?;
-                    // TODO: Consider adding a method to ScirptPublicKey for getting length directly, instead of converting to bytes first.
+                    // TODO: Consider adding a method to ScriptPublicKey for getting length directly, instead of converting to bytes first.
                     let len = utxo.script_public_key.to_bytes().len() as i64;
                     push_number(len, vm)
                 },
@@ -1286,7 +1286,7 @@ opcode_list! {
                     let [idx]: [i32; 1] = vm.dstack.pop_items()?;
                     let idx = i32_to_usize(idx)?;
                     let output = tx.outputs().get(idx).ok_or_else(|| TxScriptError::InvalidOutputIndex(idx as i32, tx.outputs().len()))?;
-                    // TODO: Consider adding a method to ScirptPublicKey for getting length directly, instead of converting to bytes first.
+                    // TODO: Consider adding a method to ScriptPublicKey for getting length directly, instead of converting to bytes first.
                     let len = output.script_public_key.to_bytes().len() as i64;
                     push_number(len, vm)
                 },
@@ -1417,7 +1417,7 @@ opcode_list! {
     opcode OpUnknown211<0xd3, 1>(self, vm) Err(TxScriptError::InvalidOpcode(format!("{self:?}")))
     opcode OpChainblockSeqCommit<0xd4, 1>(self, vm) {
         let Some(seq_commit_accessor) = vm.ctx.seq_commit_accessor else {
-            // seq_commit_access is none if only opcode is not enabled
+            // seq_commit_access is none only if the opcode is not enabled
             return Err(TxScriptError::InvalidOpcode(format!("{self:?}")))
         };
         let [block]: [Hash; 1] = vm.dstack.pop_items()?; // todo we actually could convert slice ref into hash ref if it was repr(transparent)
@@ -1519,7 +1519,7 @@ mod test {
     fn run_success_test_cases(tests: Vec<TestCase>) {
         let cache = Cache::new(10_000);
         let reused_values = SigHashReusedValuesUnsync::new();
-        let ctx = EngineContext::new(&reused_values, &cache);
+        let ctx = EngineContext::new(&cache).with_reused(&reused_values);
         for TestCase { init, code, dstack } in tests {
             let init: Stack = init.into();
             let dstack = dstack.into();
@@ -1533,7 +1533,7 @@ mod test {
     fn run_error_test_cases(tests: Vec<ErrorTestCase>) {
         let cache = Cache::new(10_000);
         let reused_values = SigHashReusedValuesUnsync::new();
-        let ctx = EngineContext::new(&reused_values, &cache);
+        let ctx = EngineContext::new(&cache).with_reused(&reused_values);
         for ErrorTestCase { init, code, error } in tests {
             let mut vm = TxScriptEngine::new(ctx, Default::default());
             vm.dstack = init.clone().into();
@@ -1570,7 +1570,7 @@ mod test {
 
         let cache = Cache::new(10_000);
         let reused_values = SigHashReusedValuesUnsync::new();
-        let ctx = EngineContext::new(&reused_values, &cache);
+        let ctx = EngineContext::new(&cache).with_reused(&reused_values);
         let mut vm = TxScriptEngine::new(ctx, Default::default());
 
         for pop in tests {
@@ -1601,7 +1601,7 @@ mod test {
 
         let cache = Cache::new(10_000);
         let reused_values = SigHashReusedValuesUnsync::new();
-        let ctx = EngineContext::new(&reused_values, &cache);
+        let ctx = EngineContext::new(&cache).with_reused(&reused_values);
         let mut vm = TxScriptEngine::new(ctx, Default::default());
 
         for pop in tests {
@@ -1676,7 +1676,7 @@ mod test {
 
         let cache = Cache::new(10_000);
         let reused_values = SigHashReusedValuesUnsync::new();
-        let ctx = EngineContext::new(&reused_values, &cache);
+        let ctx = EngineContext::new(&cache).with_reused(&reused_values);
         let mut vm = TxScriptEngine::new(ctx, Default::default());
 
         for pop in tests {
@@ -3261,7 +3261,7 @@ mod test {
 
         let sig_cache = Cache::new(10_000);
         let reused_values = SigHashReusedValuesUnsync::new();
-        let ctx = EngineContext::new(&reused_values, &sig_cache);
+        let ctx = EngineContext::new(&sig_cache).with_reused(&reused_values);
 
         let code = opcodes::OpCheckLockTimeVerify::empty().expect("Should accept empty");
 
@@ -3303,7 +3303,7 @@ mod test {
 
         let sig_cache = Cache::new(10_000);
         let reused_values = SigHashReusedValuesUnsync::new();
-        let ctx = EngineContext::new(&reused_values, &sig_cache);
+        let ctx = EngineContext::new(&sig_cache).with_reused(&reused_values);
 
         let code = opcodes::OpCheckSequenceVerify::empty().expect("Should accept empty");
 
@@ -3502,7 +3502,7 @@ mod test {
             let tx = PopulatedTransaction::new(&tx, utxo_entries);
             let sig_cache = Cache::new(10_000);
             let reused_values = SigHashReusedValuesUnsync::new();
-            let ctx = EngineContext::new(&reused_values, &sig_cache);
+            let ctx = EngineContext::new(&sig_cache).with_reused(&reused_values);
 
             for current_idx in 0..tx.inputs().len() {
                 let mut vm = TxScriptEngine::from_transaction_input(
@@ -3740,7 +3740,7 @@ mod test {
                 let tx = PopulatedTransaction::new(&tx, utxo_entries);
                 let sig_cache = Cache::new(10_000);
                 let reused_values = SigHashReusedValuesUnsync::new();
-                let ctx = EngineContext::new(&reused_values, &sig_cache);
+                let ctx = EngineContext::new(&sig_cache).with_reused(&reused_values);
 
                 let mut vm = TxScriptEngine::from_transaction_input(
                     &tx,
@@ -3805,7 +3805,7 @@ mod test {
             let tx = tx.as_verifiable();
             let sig_cache = Cache::new(10_000);
             let reused_values = SigHashReusedValuesUnsync::new();
-            let ctx = EngineContext::new(&reused_values, &sig_cache);
+            let ctx = EngineContext::new(&sig_cache).with_reused(&reused_values);
 
             // Test success case
             {
@@ -3848,7 +3848,7 @@ mod test {
                 .drain();
             let sig_cache = Cache::new(10_000);
             let reused_values = SigHashReusedValuesUnsync::new();
-            let ctx = EngineContext::new(&reused_values, &sig_cache);
+            let ctx = EngineContext::new(&sig_cache).with_reused(&reused_values);
             let spk = pay_to_script_hash_script(&redeem_script);
 
             // Test success case
@@ -3890,7 +3890,7 @@ mod test {
         fn test_input_spk_basic() {
             let sig_cache = Cache::new(10_000);
             let reused_values = SigHashReusedValuesUnsync::new();
-            let ctx = EngineContext::new(&reused_values, &sig_cache);
+            let ctx = EngineContext::new(&sig_cache).with_reused(&reused_values);
 
             // Create script: 0 OP_INPUTSPK OpNop
             // Just verify that OpInputSpk pushes something onto stack
@@ -3912,7 +3912,7 @@ mod test {
         fn test_input_spk_different() {
             let sig_cache = Cache::new(10_000);
             let reused_values = SigHashReusedValuesUnsync::new();
-            let ctx = EngineContext::new(&reused_values, &sig_cache);
+            let ctx = EngineContext::new(&sig_cache).with_reused(&reused_values);
 
             // Create script: 0 OP_INPUTSPK 1 OP_INPUTSPK OP_EQUAL OP_NOT
             // Verifies that two different inputs have different SPKs
@@ -3936,7 +3936,7 @@ mod test {
         fn test_input_spk_same() {
             let sig_cache = Cache::new(10_000);
             let reused_values = SigHashReusedValuesUnsync::new();
-            let ctx = EngineContext::new(&reused_values, &sig_cache);
+            let ctx = EngineContext::new(&sig_cache).with_reused(&reused_values);
 
             // Create script: 0 OP_INPUTSPK 1 OP_INPUTSPK OP_EQUAL
             // Verifies that two inputs with same SPK are equal
@@ -3964,7 +3964,7 @@ mod test {
             let expected_spk_bytes = expected_spk.to_bytes();
             let sig_cache = Cache::new(10_000);
             let reused_values = SigHashReusedValuesUnsync::new();
-            let ctx = EngineContext::new(&reused_values, &sig_cache);
+            let ctx = EngineContext::new(&sig_cache).with_reused(&reused_values);
             // Create script: 0 OP_OUTPUTSPK <expected_spk_bytes> EQUAL
             let redeem_script = ScriptBuilder::new()
                 .add_op(Op0)
@@ -4024,7 +4024,7 @@ mod test {
             let spk = pay_to_script_hash_script(&redeem_script);
             let sig_cache = Cache::new(10_000);
             let reused_values = SigHashReusedValuesUnsync::new();
-            let ctx = EngineContext::new(&reused_values, &sig_cache);
+            let ctx = EngineContext::new(&sig_cache).with_reused(&reused_values);
             // Test first input (success case)
             {
                 let input_mock = Kip10Mock { spk: spk.clone(), amount: 200 };
@@ -4064,7 +4064,7 @@ mod test {
         fn test_counts() {
             let sig_cache = Cache::new(10_000);
             let reused_values = SigHashReusedValuesUnsync::new();
-            let ctx = EngineContext::new(&reused_values, &sig_cache);
+            let ctx = EngineContext::new(&sig_cache).with_reused(&reused_values);
             // Test OpInputCount: "OP_INPUTCOUNT 2 EQUAL"
             let input_count_script =
                 ScriptBuilder::new().add_op(OpTxInputCount).unwrap().add_i64(2).unwrap().add_op(OpEqual).unwrap().drain();
@@ -4258,7 +4258,7 @@ mod test {
             let populated_tx = PopulatedTransaction::new(tx, entries);
             let reused_values = SigHashReusedValuesUnsync::new();
             let sig_cache = Cache::new(10_000);
-            let ctx = EngineContext::new(&reused_values, &sig_cache);
+            let ctx = EngineContext::new(&sig_cache).with_reused(&reused_values);
             let mut vm = TxScriptEngine::from_transaction_input(
                 &populated_tx,
                 &populated_tx.tx.inputs[idx],

--- a/crypto/txscript/src/opcodes/mod.rs
+++ b/crypto/txscript/src/opcodes/mod.rs
@@ -4151,8 +4151,8 @@ mod test {
         use kaspa_consensus_core::hashing::sighash::SigHashReusedValuesUnsync;
         use kaspa_consensus_core::subnets::SubnetworkId;
         use kaspa_consensus_core::tx::{
-            CovOutInfo, PopulatedTransaction, ScriptPublicKey, Transaction, TransactionInput, TransactionOutpoint, TransactionOutput,
-            UtxoEntry,
+            CovenantBinding, PopulatedTransaction, ScriptPublicKey, Transaction, TransactionInput, TransactionOutpoint,
+            TransactionOutput, UtxoEntry,
         };
         use kaspa_hashes::Hash;
 
@@ -4197,7 +4197,7 @@ mod test {
             (tx, entries)
         }
 
-        fn create_transaction_with_cov_out_info() -> (Transaction, Vec<UtxoEntry>) {
+        fn create_transaction_with_covenant() -> (Transaction, Vec<UtxoEntry>) {
             let version: u16 = 5;
             let lock_time: u64 = 0;
             let subnetwork_id = SubnetworkId::from_bytes([9u8; 20]);
@@ -4215,17 +4215,17 @@ mod test {
                 TransactionOutput {
                     value: 11,
                     script_public_key: ScriptPublicKey::new(0, spk.clone().into()),
-                    cov_out_info: Some(CovOutInfo { authorizing_input: 0, covenant_id: Hash::from_u64_word(1) }),
+                    covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: Hash::from_u64_word(1) }),
                 },
                 TransactionOutput {
                     value: 22,
                     script_public_key: ScriptPublicKey::new(0, spk.clone().into()),
-                    cov_out_info: Some(CovOutInfo { authorizing_input: 1, covenant_id: Hash::from_u64_word(2) }),
+                    covenant: Some(CovenantBinding { authorizing_input: 1, covenant_id: Hash::from_u64_word(2) }),
                 },
                 TransactionOutput {
                     value: 33,
                     script_public_key: ScriptPublicKey::new(0, spk.clone().into()),
-                    cov_out_info: Some(CovOutInfo { authorizing_input: 0, covenant_id: Hash::from_u64_word(3) }),
+                    covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: Hash::from_u64_word(3) }),
                 },
                 TransactionOutput::new(44, ScriptPublicKey::new(0, spk.into())),
             ];
@@ -4440,7 +4440,7 @@ mod test {
 
         #[test]
         fn cov_output_count() {
-            let (tx, entries) = create_transaction_with_cov_out_info();
+            let (tx, entries) = create_transaction_with_covenant();
 
             for (input_idx, expected_count) in [(0, 2), (1, 1)] {
                 let spk = script(|sb| {
@@ -4456,7 +4456,7 @@ mod test {
 
         #[test]
         fn cov_output_idx() {
-            let (tx, entries) = create_transaction_with_cov_out_info();
+            let (tx, entries) = create_transaction_with_covenant();
 
             for (input_idx, authorized_idx, expected_output_idx) in [(0, 0, 0), (0, 1, 2), (1, 0, 1)] {
                 let spk = script(|sb| {

--- a/crypto/txscript/src/opcodes/mod.rs
+++ b/crypto/txscript/src/opcodes/mod.rs
@@ -9,6 +9,7 @@ use blake2b_simd::Params;
 use kaspa_consensus_core::hashing::sighash::SigHashReusedValues;
 use kaspa_consensus_core::hashing::sighash_type::SigHashType;
 use kaspa_consensus_core::tx::VerifiableTransaction;
+use kaspa_hashes::Hash;
 use sha2::{Digest, Sha256};
 use std::{
     fmt::{Debug, Formatter},
@@ -1414,7 +1415,22 @@ opcode_list! {
     opcode OpUnknown209<0xd1, 1>(self, vm) Err(TxScriptError::InvalidOpcode(format!("{self:?}")))
     opcode OpUnknown210<0xd2, 1>(self, vm) Err(TxScriptError::InvalidOpcode(format!("{self:?}")))
     opcode OpUnknown211<0xd3, 1>(self, vm) Err(TxScriptError::InvalidOpcode(format!("{self:?}")))
-    opcode OpUnknown212<0xd4, 1>(self, vm) Err(TxScriptError::InvalidOpcode(format!("{self:?}")))
+    opcode OpChainblockSeqCommit<0xd4, 1>(self, vm) {
+        let Some(seq_commit_accessor) = vm.ctx.seq_commit_accessor else {
+            // seq_commit_access is none if only opcode is not enabled
+            return Err(TxScriptError::InvalidOpcode(format!("{self:?}")))
+        };
+        let [block]: [Hash; 1] = vm.dstack.pop_items()?; // todo we actually could convert slice ref into hash ref if it was repr(transparent)
+        match seq_commit_accessor.is_chain_ancestor_from_pov(block) {
+            None => return Err(TxScriptError::BlockAlreadyPruned(block.to_string())),
+            Some(false) => return Err(TxScriptError::BlockNotSelected(block.to_string())),
+            Some(true) => {}
+        };
+        let commitment = seq_commit_accessor.seq_commitment_within_depth(block)
+            .ok_or_else(|| TxScriptError::BlockIsTooDeep(block.to_string()))?;
+        vm.dstack.push_item(commitment)?;
+        Ok(())
+    }
     opcode OpUnknown213<0xd5, 1>(self, vm) Err(TxScriptError::InvalidOpcode(format!("{self:?}")))
     opcode OpUnknown214<0xd6, 1>(self, vm) Err(TxScriptError::InvalidOpcode(format!("{self:?}")))
     opcode OpUnknown215<0xd7, 1>(self, vm) Err(TxScriptError::InvalidOpcode(format!("{self:?}")))
@@ -1618,7 +1634,7 @@ mod test {
             opcodes::OpUnknown209::empty().expect("Should accept empty"),
             opcodes::OpUnknown210::empty().expect("Should accept empty"),
             opcodes::OpUnknown211::empty().expect("Should accept empty"),
-            opcodes::OpUnknown212::empty().expect("Should accept empty"),
+            opcodes::OpChainblockSeqCommit::empty().expect("Should accept empty"),
             opcodes::OpUnknown213::empty().expect("Should accept empty"),
             opcodes::OpUnknown214::empty().expect("Should accept empty"),
             opcodes::OpUnknown215::empty().expect("Should accept empty"),

--- a/crypto/txscript/src/seq_commit_accessor.rs
+++ b/crypto/txscript/src/seq_commit_accessor.rs
@@ -1,0 +1,6 @@
+use kaspa_hashes::Hash;
+
+pub trait SeqCommitAccessor: Sync {
+    fn is_chain_ancestor_from_pov(&self, block_hash: Hash) -> Option<bool>;
+    fn seq_commitment_within_depth(&self, block_hash: Hash) -> Option<Hash>;
+}

--- a/crypto/txscript/src/standard/multisig.rs
+++ b/crypto/txscript/src/standard/multisig.rs
@@ -185,7 +185,7 @@ mod tests {
         let (input, entry) = tx.populated_inputs().next().unwrap();
 
         let cache = Cache::new(10_000);
-        let ctx = EngineContext::new(&reused_values, &cache);
+        let ctx = EngineContext::new(&cache).with_reused(&reused_values);
         let mut engine = TxScriptEngine::from_transaction_input(&tx, input, 0, entry, ctx, Default::default());
         assert_eq!(engine.execute().is_ok(), is_ok);
     }

--- a/crypto/txscript/src/standard/multisig.rs
+++ b/crypto/txscript/src/standard/multisig.rs
@@ -70,7 +70,7 @@ pub fn multisig_redeem_script_ecdsa(pub_keys: impl Iterator<Item = impl Borrow<[
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{caches::Cache, opcodes::codes::OpData65, pay_to_script_hash_script, TxScriptEngine};
+    use crate::{caches::Cache, opcodes::codes::OpData65, pay_to_script_hash_script, EngineContext, TxScriptEngine};
     use core::str::FromStr;
     use kaspa_consensus_core::{
         hashing::{
@@ -185,7 +185,8 @@ mod tests {
         let (input, entry) = tx.populated_inputs().next().unwrap();
 
         let cache = Cache::new(10_000);
-        let mut engine = TxScriptEngine::from_transaction_input(&tx, input, 0, entry, &reused_values, &cache, Default::default());
+        let ctx = EngineContext::new(&reused_values, &cache);
+        let mut engine = TxScriptEngine::from_transaction_input(&tx, input, 0, entry, ctx, Default::default());
         assert_eq!(engine.execute().is_ok(), is_ok);
     }
     #[test]

--- a/crypto/txscript/test-data/script_tests_covenants.json
+++ b/crypto/txscript/test-data/script_tests_covenants.json
@@ -3927,6 +3927,13 @@
     "OpTxOutputSpk is enabled since kip10"
   ],
   [
+    "'output_root_hashffffffffffffffff' 'input_blockfffffffffffffffffffff'",
+    "0xd4 EQUAL",
+    "",
+    "OK",
+    "OpChainblockSeqCommit puts the block sequence commitment on the stack"
+  ],
+  [
     "TODO (before merge): Add tests for the missing range 0xc4 to 0xca"
   ],
   [
@@ -4067,12 +4074,6 @@
   [
     "1",
     "IF 0xd3 ELSE 1 ENDIF",
-    "",
-    "BAD_OPCODE"
-  ],
-  [
-    "1",
-    "IF 0xd4 ELSE 1 ENDIF",
     "",
     "BAD_OPCODE"
   ],

--- a/mining/src/mempool/populate_entries_and_try_validate.rs
+++ b/mining/src/mempool/populate_entries_and_try_validate.rs
@@ -19,7 +19,7 @@ impl Mempool {
                     output.script_public_key.clone(),
                     UNACCEPTED_DAA_SCORE,
                     false,
-                    output.cov_out_info.map(|x| x.covenant_id),
+                    output.covenant.map(|x| x.covenant_id),
                 ));
             }
         }

--- a/mining/src/mempool/validate_and_insert_transaction.rs
+++ b/mining/src/mempool/validate_and_insert_transaction.rs
@@ -179,7 +179,7 @@ impl Mempool {
                                 output.script_public_key.clone(),
                                 UNACCEPTED_DAA_SCORE,
                                 false,
-                                output.cov_out_info.map(|x| x.covenant_id),
+                                output.covenant.map(|x| x.covenant_id),
                             );
                             orphan.mtx.entries[i] = Some(entry);
                             if orphan.mtx.is_verifiable() {

--- a/mining/src/testutils/consensus_mock.rs
+++ b/mining/src/testutils/consensus_mock.rs
@@ -61,7 +61,7 @@ impl ConsensusMock {
                     x.script_public_key.clone(),
                     block_daa_score,
                     transaction.tx.is_coinbase(),
-                    x.cov_out_info.map(|y| y.covenant_id),
+                    x.covenant.map(|y| y.covenant_id),
                 ),
             );
         });

--- a/rothschild/benches/bench.rs
+++ b/rothschild/benches/bench.rs
@@ -16,7 +16,7 @@ fn constuct_tx() -> Transaction {
         sig_op_count: 1,
     }];
     let outputs =
-        vec![TransactionOutput { value: 10000, script_public_key: ScriptPublicKey::from_vec(0, vec![0xff; 35]), cov_out_info: None }];
+        vec![TransactionOutput { value: 10000, script_public_key: ScriptPublicKey::from_vec(0, vec![0xff; 35]), covenant: None }];
     Transaction::new(TX_VERSION, inputs, outputs, 0, SUBNETWORK_ID_NATIVE, 0, vec![])
 }
 

--- a/rothschild/src/main.rs
+++ b/rothschild/src/main.rs
@@ -537,7 +537,7 @@ fn generate_tx(
         .collect_vec();
 
     let outputs = (0..num_outs)
-        .map(|_| TransactionOutput { value: send_amount / num_outs, script_public_key: script_public_key.clone(), cov_out_info: None })
+        .map(|_| TransactionOutput { value: send_amount / num_outs, script_public_key: script_public_key.clone(), covenant: None })
         .collect_vec();
     let mut data = vec![0u8; payload_size];
     rand::thread_rng().fill_bytes(&mut data);

--- a/rpc/core/src/model/optional/tx.rs
+++ b/rpc/core/src/model/optional/tx.rs
@@ -57,7 +57,7 @@ impl From<UtxoEntry> for RpcOptionalUtxoEntry {
             block_daa_score: Some(entry.block_daa_score),
             is_coinbase: Some(entry.is_coinbase),
             verbose_data: None,
-            covenant_id: entry.covenant_id.into(),
+            covenant_id: entry.covenant_id,
         }
     }
 }

--- a/testing/integration/src/common/utils.rs
+++ b/testing/integration/src/common/utils.rs
@@ -79,7 +79,7 @@ pub fn generate_tx_dag(
                 let total_in = entries.iter().map(|e| e.amount).sum::<u64>();
                 let total_out = total_in - required_fee(num_inputs, num_outputs);
                 let outputs = (0..num_outputs)
-                    .map(|_| TransactionOutput { value: total_out / num_outputs, script_public_key: spk.clone(), cov_out_info: None })
+                    .map(|_| TransactionOutput { value: total_out / num_outputs, script_public_key: spk.clone(), covenant: None })
                     .collect_vec();
                 let unsigned_tx = Transaction::new(TX_VERSION, inputs, outputs, 0, SUBNETWORK_ID_NATIVE, 0, vec![]);
                 sign(SignableTransaction::with_entries(unsigned_tx, entries), schnorr_key)
@@ -150,7 +150,7 @@ pub fn generate_tx(
         .collect_vec();
 
     let outputs = (0..num_outputs)
-        .map(|_| TransactionOutput { value: amount / num_outputs, script_public_key: script_public_key.clone(), cov_out_info: None })
+        .map(|_| TransactionOutput { value: amount / num_outputs, script_public_key: script_public_key.clone(), covenant: None })
         .collect_vec();
     let unsigned_tx = Transaction::new(TX_VERSION, inputs, outputs, 0, SUBNETWORK_ID_NATIVE, 0, vec![]);
     let signed_tx =

--- a/wallet/core/src/account/pskb.rs
+++ b/wallet/core/src/account/pskb.rs
@@ -330,6 +330,7 @@ pub fn pskt_to_pending_transaction(
                             script_public_key: ue.script_public_key.clone(),
                             block_daa_score: ue.block_daa_score,
                             is_coinbase: ue.is_coinbase,
+                            covenant_id: ue.covenant_id,
                         }),
                     },
                     ue.amount,

--- a/wallet/core/src/api/message.rs
+++ b/wallet/core/src/api/message.rs
@@ -630,6 +630,7 @@ impl From<UtxoEntryWrapper> for UtxoEntry {
             script_public_key: entry.script_public_key,
             block_daa_score: entry.block_daa_score,
             is_coinbase: entry.is_coinbase,
+            covenant_id: None,
         }
     }
 }

--- a/wallet/core/src/api/message.rs
+++ b/wallet/core/src/api/message.rs
@@ -630,7 +630,7 @@ impl From<UtxoEntryWrapper> for UtxoEntry {
             script_public_key: entry.script_public_key,
             block_daa_score: entry.block_daa_score,
             is_coinbase: entry.is_coinbase,
-            covenant_id: None,
+            covenant_id: todo!(),
         }
     }
 }

--- a/wallet/core/src/tx/generator/generator.rs
+++ b/wallet/core/src/tx/generator/generator.rs
@@ -1200,6 +1200,7 @@ impl Generator {
             script_public_key,
             block_daa_score: UNACCEPTED_DAA_SCORE,
             is_coinbase: false, // entry
+            covenant_id: None,
         };
         UtxoEntryReference { utxo: Arc::new(utxo) }
     }

--- a/wallet/core/src/tx/generator/generator.rs
+++ b/wallet/core/src/tx/generator/generator.rs
@@ -1200,7 +1200,7 @@ impl Generator {
             script_public_key,
             block_daa_score: UNACCEPTED_DAA_SCORE,
             is_coinbase: false, // entry
-            covenant_id: None,
+            covenant_id: todo!(),
         };
         UtxoEntryReference { utxo: Arc::new(utxo) }
     }

--- a/wallet/core/src/tx/payment.rs
+++ b/wallet/core/src/tx/payment.rs
@@ -110,7 +110,7 @@ impl From<PaymentOutput> for TransactionOutput {
         Self::new_with_inner(TransactionOutputInner {
             script_public_key: pay_to_address_script(&value.address),
             value: value.amount,
-            cov_out_info: None,
+            covenant: todo!(),
         })
     }
 }

--- a/wallet/core/src/tx/payment.rs
+++ b/wallet/core/src/tx/payment.rs
@@ -107,7 +107,11 @@ impl PaymentOutput {
 
 impl From<PaymentOutput> for TransactionOutput {
     fn from(value: PaymentOutput) -> Self {
-        Self::new_with_inner(TransactionOutputInner { script_public_key: pay_to_address_script(&value.address), value: value.amount })
+        Self::new_with_inner(TransactionOutputInner {
+            script_public_key: pay_to_address_script(&value.address),
+            value: value.amount,
+            cov_out_info: None,
+        })
     }
 }
 

--- a/wallet/pskt/examples/multisig.rs
+++ b/wallet/pskt/examples/multisig.rs
@@ -27,6 +27,7 @@ fn main() {
             script_public_key: pay_to_script_hash_script(&redeem_script),
             block_daa_score: 36151168,
             is_coinbase: false,
+            covenant_id: Default::default(),
         })
         .previous_outpoint(TransactionOutpoint {
             transaction_id: TransactionId::from_str("63020db736215f8b1105a9281f7bcbb6473d965ecc45bb2fb5da59bd35e6ff84").unwrap(),

--- a/wallet/pskt/src/convert.rs
+++ b/wallet/pskt/src/convert.rs
@@ -45,7 +45,7 @@ impl TryFrom<TransactionOutput> for Output {
     fn try_from(output: TransactionOutput) -> std::result::Result<Output, Self::Error> {
         // Self::Transaction(transaction)
 
-        let TransactionOutputInner { value, script_public_key } = &*output.inner();
+        let TransactionOutputInner { value, script_public_key, .. } = &*output.inner();
 
         let output = OutputBuilder::default()
         .amount(*value)

--- a/wallet/pskt/src/convert.rs
+++ b/wallet/pskt/src/convert.rs
@@ -45,7 +45,8 @@ impl TryFrom<TransactionOutput> for Output {
     fn try_from(output: TransactionOutput) -> std::result::Result<Output, Self::Error> {
         // Self::Transaction(transaction)
 
-        let TransactionOutputInner { value, script_public_key, .. } = &*output.inner();
+        // TODO: covenant
+        let TransactionOutputInner { value, script_public_key, covenant } = &*output.inner();
 
         let output = OutputBuilder::default()
         .amount(*value)

--- a/wallet/pskt/src/pskt.rs
+++ b/wallet/pskt/src/pskt.rs
@@ -4,6 +4,7 @@
 
 use kaspa_bip32::{secp256k1, DerivationPath, KeyFingerprint};
 use kaspa_consensus_core::{hashing::sighash::SigHashReusedValuesUnsync, Hash};
+use kaspa_txscript::EngineContext;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::{collections::BTreeMap, fmt::Display, fmt::Formatter, future::Future, marker::PhantomData, ops::Deref};
@@ -469,10 +470,10 @@ impl PSKT<Extractor> {
             let tx = tx.as_verifiable();
             let cache = Cache::new(10_000);
             let reused_values = SigHashReusedValuesUnsync::new();
+            let ctx = EngineContext::new(&reused_values, &cache);
 
             tx.populated_inputs().enumerate().try_for_each(|(idx, (input, entry))| {
-                TxScriptEngine::from_transaction_input(&tx, input, idx, entry, &reused_values, &cache, Default::default())
-                    .execute()?;
+                TxScriptEngine::from_transaction_input(&tx, input, idx, entry, ctx, Default::default()).execute()?;
                 <Result<(), ExtractError>>::Ok(())
             })?;
         }

--- a/wallet/pskt/src/pskt.rs
+++ b/wallet/pskt/src/pskt.rs
@@ -148,6 +148,7 @@ impl<R> PSKT<R> {
                 .map(|Output { amount, script_public_key, .. }: &Output| TransactionOutput {
                     value: *amount,
                     script_public_key: script_public_key.clone(),
+                    cov_out_info: None,
                 })
                 .collect(),
             self.determine_lock_time(),

--- a/wallet/pskt/src/pskt.rs
+++ b/wallet/pskt/src/pskt.rs
@@ -149,7 +149,7 @@ impl<R> PSKT<R> {
                 .map(|Output { amount, script_public_key, .. }: &Output| TransactionOutput {
                     value: *amount,
                     script_public_key: script_public_key.clone(),
-                    cov_out_info: None,
+                    covenant: todo!(),
                 })
                 .collect(),
             self.determine_lock_time(),

--- a/wallet/pskt/src/pskt.rs
+++ b/wallet/pskt/src/pskt.rs
@@ -4,7 +4,7 @@
 
 use kaspa_bip32::{secp256k1, DerivationPath, KeyFingerprint};
 use kaspa_consensus_core::{hashing::sighash::SigHashReusedValuesUnsync, Hash};
-use kaspa_txscript::EngineContext;
+use kaspa_txscript::EngineCtx;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::{collections::BTreeMap, fmt::Display, fmt::Formatter, future::Future, marker::PhantomData, ops::Deref};
@@ -470,7 +470,7 @@ impl PSKT<Extractor> {
             let tx = tx.as_verifiable();
             let cache = Cache::new(10_000);
             let reused_values = SigHashReusedValuesUnsync::new();
-            let ctx = EngineContext::new(&reused_values, &cache);
+            let ctx = EngineCtx::new(&cache).with_reused(&reused_values);
 
             tx.populated_inputs().enumerate().try_for_each(|(idx, (input, entry))| {
                 TxScriptEngine::from_transaction_input(&tx, input, idx, entry, ctx, Default::default()).execute()?;


### PR DESCRIPTION
- composes the covenants context externally in one linear pass (for all inputs and outputs) 
- refactors sig cache and reused values + new covenants ctx into a single engine ctx object